### PR TITLE
Manage different newlines ('\r\n', '\n') with the Transcriber

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -26,9 +26,8 @@ class AndroidHandler(Handler):
 
         resources_tag_position = content.index("<resources")
 
-        source = content[resources_tag_position:]
-
-        self.transcriber = Transcriber(source)
+        self.transcriber = Transcriber(content[resources_tag_position:])
+        source = self.transcriber.source
 
         self._order = 0
 
@@ -204,8 +203,8 @@ class AndroidHandler(Handler):
         self._stringset = list(stringset)
         self._stringset_index = 0
 
-        self.source = template[resources_tag_position:]
-        self.transcriber = Transcriber(self.source)
+        self.transcriber = Transcriber(template[resources_tag_position:])
+        self.source = self.transcriber.source
 
         resources_tag = DumbXml(self.source)
 
@@ -222,8 +221,8 @@ class AndroidHandler(Handler):
         self.transcriber.copy_until(len(self.source))
 
         # Lets do another pass to clear empty <string-array>s
-        self.source = self.transcriber.get_destination()
-        self.transcriber = Transcriber(self.source)
+        self.transcriber = Transcriber(self.transcriber.get_destination())
+        self.source = self.transcriber.source
         resources_tag = DumbXml(self.source)
         for string_array_tag, string_array_offset in resources_tag.find(
                 "string-array"):

--- a/openformats/formats/srt.py
+++ b/openformats/formats/srt.py
@@ -22,14 +22,11 @@ class SrtHandler(Handler):
             start += len(section) + 2
 
     def parse(self, content):
-        if not isinstance(content, unicode):
-            content = content.decode("utf-8")
-        content = content.replace(u'\r\n', u'\n')
-
         self.transcriber = Transcriber(content)
+        source = self.transcriber.source
         stringset = []
         self.max_order = None
-        for start, subtitle_section in self._generate_split_subtitles(content):
+        for start, subtitle_section in self._generate_split_subtitles(source):
             self.transcriber.copy_until(start)
             offset, string = self._parse_section(start, subtitle_section)
 
@@ -42,7 +39,7 @@ class SrtHandler(Handler):
             else:
                 self.transcriber.copy_until(start + len(subtitle_section))
 
-        self.transcriber.copy_until(len(content))
+        self.transcriber.copy_until(len(source))
 
         template = self.transcriber.get_destination()
         return template, stringset
@@ -146,6 +143,7 @@ class SrtHandler(Handler):
 
     def compile(self, template, stringset):
         transcriber = Transcriber(template)
+        template = transcriber.source
         stringset = iter(stringset)
         string = stringset.next()
 

--- a/openformats/utils/compilers.py
+++ b/openformats/utils/compilers.py
@@ -9,6 +9,7 @@ class OrderedCompilerMixin(object):
     def compile(self, template, stringset):
         # assume stringset is ordered within the template
         transcriber = Transcriber(template)
+        template = transcriber.source
 
         for string in stringset:
             hash_position = template.index(string.template_replacement)


### PR DESCRIPTION
@lolletsoc just an idea I had about handling different types of newline sequences (unix/dos) without really having to handle them.