### PR TITLE
Android v2 escape

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -21,7 +21,7 @@ class AndroidHandler(Handler):
     name = "ANDROID"
     extension = "xml"
 
-    EXTRACTS_RAW = False
+    EXTRACTS_RAW = True
 
     # Where to start parsing the file
     PARSE_START = "<resources"
@@ -546,3 +546,20 @@ class AndroidHandler(Handler):
             if filter_attr is not None and filter_attr == value:
                 return True
         return False
+
+    # Escaping / Unescaping
+    # According to:
+    # http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling  # noqa
+
+    @staticmethod
+    def escape(string):
+        return string.replace('\\', '\\\\').replace('"', '\\"').\
+            replace("'", "\\'")
+
+    @staticmethod
+    def unescape(string):
+        if len(string) and string[0] == string[-1] == '"':
+            return string[1:-1]
+        else:
+            return string.replace('\\"', '"').replace("\\'", "'").\
+                replace('\\\\', '\\')

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -618,3 +618,20 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             '''
         )
         self.assertTrue(stringset[0].pluralized)
+
+    def test_escape(self):
+        cases = (('double " quote', 'double \\" quote'),
+                 ("single ' quote", "single \\' quote"),
+                 ("back \\ slash", "back \\\\ slash"))
+        for rich, raw in cases:
+            self.assertEquals(AndroidHandler.escape(rich), raw)
+
+    def test_unescape(self):
+        cases = (('double " quote', 'double \\" quote'),
+                 ("single ' quote", "single \\' quote"),
+                 ("back \\ slash", "back \\\\ slash"),
+                 ('inside double quotes', '"inside double quotes"'),
+                 ("single ' quote", '"single \' quote"'),
+                 ("back \\ slash", '"back \\ slash"'))
+        for rich, raw in cases:
+            self.assertEquals(AndroidHandler.unescape(raw), rich)


### PR DESCRIPTION
 Added un/escape functions to Android format

According to rules described here:
http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling

Check this out:

```
In [13]: c.create_new_resource('android', 'android', 'BETA_ANDROID', content=u'''
             <resources>
                <string name="backslashed">a\\'b</string>
                <string name="doublequoted">"a'b"</string>
            </resources>
         ''')
Out[13]: <Response [201]>

In [14]: # After translating both strings with `α'β` in "rich" mode on transifex:

In [14]: print c.get('/project/android/resource/android/translation/el/').json()['content']

<resources>
    <string name="backslashed">α\'β</string>
    <string name="doublequoted">α\'β</string>
</resources>
```