### PR TITLE
Small fix to take care languages with one plural rule.

### DIFF
--- a/testbed/main/views.py
+++ b/testbed/main/views.py
@@ -134,7 +134,6 @@ class ApiView(HandlerMixin, View):
             key = string_json.pop('key')
             strings = {int(key): value
                        for key, value in string_json.pop('strings').items()}
-            del string_json['pluralized']
             del string_json['template_replacement']
             stringset.append(OpenString(key, strings, **string_json))
 


### PR DESCRIPTION
When a language contains only one plural, on compilation of a file the string is treated as not pluralised.
This fixes the issue but retaining the strings pluralised property.