### PR TITLE
android plural fix for same tag_names

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -249,14 +249,20 @@ class AndroidHandler(Handler):
                 if child.tag in self.existing_hashes[(name, product)]:
                     format_dict = {
                         'name': name,
-                        'product': product,
                         'child_tag': child.tag
                     }
-                    msg = (
-                        u"Duplicate `tag_name` ({child_tag}) for `name`"
-                        u" ({name}) and `product` ({product}) "
-                        u"found on line {line_number}"
-                    )
+                    if product:
+                        msg = (
+                            u"Duplicate `tag_name` ({child_tag}) for `name`"
+                            u" ({name}) and `product` ({product}) "
+                            u"found on line {line_number}"
+                        )
+                        format_dict['product'] = product
+                    else:
+                        msg = (
+                            u"Duplicate `tag_name` ({child_tag}) for `name`"
+                            u" ({name}) spcesify a product to differenciate"
+                        )
                     XMLUtils.raise_error(
                         self.transcriber,
                         child,

--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -257,6 +257,12 @@ class AndroidHandler(Handler):
             # If duplicate hash raise ParseError
             if string.string_hash in self.existing_hashes:
                 format_dict = {'name': name}
+                # add product if not here to allow some names for plurals
+                # and re-attempt
+                if not product and pluralized:
+                    product = 'plural_with_same_name'
+                    return self._create_string(name, text, comment,
+                                               product, child, pluralized=True)
                 if not product:
                     msg = (
                         u"Duplicate `name` ({name}) attribute found on line "

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -107,6 +107,51 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
         self.assertEquals(stringset[0].__dict__, random_openstring.__dict__)
         self.assertEquals(compiled, source)
 
+    def test_plurals_with_same_name_as_parent(self):
+        random_key = generate_random_string()
+        random_singular = generate_random_string()
+        random_plural = generate_random_string()
+        product = 'plural_with_same_name'
+        random_openstring = OpenString(random_key,
+                                       {1: random_singular, 5: random_plural},
+                                       context=product, order=0)
+        random_hash = random_openstring.template_replacement
+
+        plural_text = generate_random_string()
+
+        plural_openstring = OpenString(random_key, plural_text)
+        random_hash_simple = plural_openstring.template_replacement
+
+        source = strip_leading_spaces(u"""
+            <resources>
+                <string name="{key}"> {simple_text}</string>
+                <plurals name="{key}">
+                    <item quantity="one">{singular}</item>
+                    <item quantity="other">{plural}</item>
+                </plurals>
+            </resources>
+        """.format(key=random_key, simple_text=plural_text,
+                   singular=random_singular,
+                   plural=random_plural))
+
+        template, stringset = self.handler.parse(source)
+
+        compiled = self.handler.compile(template, stringset)
+
+        self.assertEquals(
+            template,
+            strip_leading_spaces(u'''
+                <resources>
+                    <string name="{key}">{hash_simple}</string>
+                    <plurals name="{key}">
+                        {hash_}
+                    </plurals>
+                </resources>
+            '''.format(key=random_key, hash_simple=random_hash_simple,
+                       hash_=random_hash))
+        )
+        self.assertEquals(compiled, source)
+
     def test_no_translatable(self):
         random_key = generate_random_string()
         random_string = generate_random_string()


### PR DESCRIPTION
@kbairak cloud you plz review it? 

Description:

Assume we have the following source content: 
```<?xml version="1.0" encoding="utf-8"?>
<resources>
  <string name="test"> this is just a test string</string>
  <plurals name="test">
    <item quantity="one"> One</item>
    <item quantity="other"> other</item>
  </plurals>
</resources>
```
If we try to compile it the Compiler gives -> `Duplicate "name" (test) attribute found on line 4. Specify a "product" to differentiate `

Since it's a valid XML we should handle it and allow it as source content.