### PR TITLE
Android compile non translatable

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -351,7 +351,7 @@ class AndroidHandler(Handler):
 
     """ Compile Methods """
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, is_source=True):
         resources_tag_position = template.index(self.PARSE_START)
 
         self.transcriber = Transcriber(template[resources_tag_position:])
@@ -369,6 +369,7 @@ class AndroidHandler(Handler):
             self.STRING_PLURAL
         )
 
+        self.is_source = is_source
         self.stringset = iter(stringset)
         self.next_string = self._get_next_string()
         for child in children_itterator:
@@ -393,7 +394,10 @@ class AndroidHandler(Handler):
             elif child.tag == self.STRING_PLURAL:
                 self._compile_string_plural(child)
         else:
-            self.transcriber.copy_until(child.end)
+            if self.is_source:
+                self.transcriber.copy_until(child.end)
+            else:
+                self._skip_tag(child)
 
     def _compile_string(self, child):
         """Handles child element that has the `string` and `item` tag.

--- a/openformats/formats/beta_android.py
+++ b/openformats/formats/beta_android.py
@@ -207,7 +207,7 @@ class BetaAndroidHandler(Handler):
                 return True
         return False
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, **kwargs):
         resources_tag_position = template.index("<resources")
         self._stringset = list(stringset)
         self._stringset_index = 0

--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -96,7 +96,7 @@ class JsonHandler(Handler):
         key = key.replace(u".", u"\\.")
         return key
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, **kwargs):
         # Lets play on the template first, we need it to not include the hashes
         # that aren't in the stringset. For that we will create a new stringset
         # which will have the hashes themselves as strings and compile against

--- a/openformats/formats/po.py
+++ b/openformats/formats/po.py
@@ -265,7 +265,7 @@ class PoHandler(Handler):
             entry.msgstr_plural = {'0': openstring.template_replacement}
         return openstring
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, **kwargs):
         stringset = iter(stringset)
         next_string = next(stringset, None)
 

--- a/openformats/formats/srt.py
+++ b/openformats/formats/srt.py
@@ -141,7 +141,7 @@ class SrtHandler(Handler):
         return "{:02}:{:02}:{:02}.{:03}".format(hours, minutes, seconds,
                                                 milliseconds)
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, **kwargs):
         transcriber = Transcriber(template)
         template = transcriber.source
         stringset = iter(stringset)

--- a/openformats/formats/stringsdict.py
+++ b/openformats/formats/stringsdict.py
@@ -282,7 +282,7 @@ class StringsDictHandler(Handler):
 
     """ Compile Methods """
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, **kwargs):
         dict_tag_position = template.index(self.PARSE_START)
 
         self.transcriber = Transcriber(template[dict_tag_position:])

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -687,3 +687,32 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             u'<resources><plurals name="a" /></resources>',
             u'No plurals found in <plurals> tag on line 1'
         )
+
+    def test_compile_for_target_language_clears_untranslatable_strings(self):
+        string = OpenString(generate_random_string(), generate_random_string(),
+                            order=0)
+        template = """
+            <resources>
+                <string name="untranslatable"
+                        translatable="false">Untranslatable</string>
+                <string name="{key}">{string}</string>
+            </resources>
+        """.format(key=string.key, string=string.template_replacement)
+
+        # Try for source
+        compiled = self.handler.compile(template, [string], is_source=True)
+        self.assertEquals(compiled, """
+            <resources>
+                <string name="untranslatable"
+                        translatable="false">Untranslatable</string>
+                <string name="{key}">{string}</string>
+            </resources>
+        """.format(key=string.key, string=string.string))
+
+        # Try for translation
+        compiled = self.handler.compile(template, [string], is_source=False)
+        self.assertEquals(compiled, """
+            <resources>
+                <string name="{key}">{string}</string>
+            </resources>
+        """.format(key=string.key, string=string.string))

--- a/openformats/utils/compilers.py
+++ b/openformats/utils/compilers.py
@@ -6,7 +6,7 @@ from openformats.transcribers import Transcriber
 class OrderedCompilerMixin(object):
     SPACE_PAT = re.compile(r'^\s*$')
 
-    def compile(self, template, stringset):
+    def compile(self, template, stringset, **kwargs):
         # assume stringset is ordered within the template
         transcriber = Transcriber(template)
         template = transcriber.source


### PR DESCRIPTION
[TX-7091](https://transifex.atlassian.net/browse/TX-7091)

When compiling android files for translation, the handler should skip the tags marked with `translatable="false"`.

This adds a new kwarg to the compile method of **all** handlers, `is_source`. This is what tells the handler to either include or skip the untranslatable strings.

After this is merged, we should make a [change to transifex](https://github.com/transifex/txc/pull/3892) to pass this option when invoking the compile method.