### PR TITLE
Better handling of backslashes on JSON

### DIFF
--- a/openformats/tests/util_tests/test_json.py
+++ b/openformats/tests/util_tests/test_json.py
@@ -72,6 +72,22 @@ class DumbJsonTestCase(unittest.TestCase):
         self._test_dfs('["a", {"b": "c"}]',
                        [("a", 2), ([("b", 8, "c", 13)], 6)])
 
+    # Escaping
+    def test_escape_quotes(self):
+        # Actual string looks like: 'hello \" world'
+        self._test_dfs('{"a": "hello \\" world"}',
+                       [('a', 2, 'hello \\" world', 7)])
+
+    def test_double_backslashes(self):
+        # Actual string looks like: 'hello \\ world'
+        self._test_dfs('{"a": "hello \\\\ world"}',
+                       [('a', 2, 'hello \\\\ world', 7)])
+
+    def test_double_backslashes_with_quotes(self):
+        # Actual string looks like: 'hello world\\'
+        self._test_dfs('{"a": "hello world\\\\"}',
+                       [('a', 2, 'hello world\\\\', 7)])
+
     # Utils
     def _test_dfs(self, content, against):
         dumb_json = DumbJson(content)

--- a/openformats/utils/json.py
+++ b/openformats/utils/json.py
@@ -175,13 +175,17 @@ class DumbJson(object):
 
     def _find_next(self, symbols, start=0, require_whitespace=True):
         symbols = {s for s in symbols}
+        after_backslash = False
         for ptr in xrange(start, len(self.source)):
             candidate = self.source[ptr]
+            if candidate == '\\':
+                after_backslash = not after_backslash
             if candidate in symbols:
-                if (candidate == '"' and ptr > 0 and
-                        self.source[ptr - 1] == '\\'):
+                if candidate == '"' and after_backslash:
                     continue
                 return candidate, ptr
+            if candidate != '\\':
+                after_backslash = False
             if require_whitespace and not candidate.isspace():
                 newline_count = self.source.count('\n', 0, ptr)
                 raise ValueError(

--- a/openformats/utils/json.py
+++ b/openformats/utils/json.py
@@ -182,6 +182,7 @@ class DumbJson(object):
                 after_backslash = not after_backslash
             if candidate in symbols:
                 if candidate == '"' and after_backslash:
+                    after_backslash = False
                     continue
                 return candidate, ptr
             if candidate != '\\':


### PR DESCRIPTION
Previously, in strings like: `{"a": "b\\"}`, the parser would consider
the last double-quote as escaped, and thus not know when the string
ends. In fact, the first backslash escapes the second one and the
double-quote should be considered as the end of the string.

This fix makes sure the first backslash escapes the character after it
and, if the character after it is a backslash too, the second one does
not escape the next character.