### PR TITLE
upgrade mistune to next version and use expandtabs

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -177,7 +177,11 @@ class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
 
     def parse(self, content, **kwargs):
 
-        template = content
+        # mistune expands tabs to 4 spaces and trims trailing spaces, so we
+        # need to do the same in order to be able to match the substrings
+        template = content.expandtabs(4)
+        pattern = re.compile(r'^ +$', re.M)
+        template = pattern.sub('', template)
         stringset = []
 
         yml_header = re.match(r'^(---\s+)([\s\S]*?[^`])\s*(\n---\s+)(?!-)',

--- a/openformats/tests/formats/github_markdown/files/2_el.md
+++ b/openformats/tests/formats/github_markdown/files/2_el.md
@@ -1,0 +1,13 @@
+---
+title: el:About writing and formatting on GitHub
+
+---
+
+# el:Markdown stuff
+
+### el:Old version
+
+el:This line ends with a tab.  
+And this is a new line.
+
+el:previous line contains spaces.

--- a/openformats/tests/formats/github_markdown/files/2_en.md
+++ b/openformats/tests/formats/github_markdown/files/2_en.md
@@ -1,0 +1,13 @@
+---
+title: About writing and formatting on GitHub
+
+---
+
+# Markdown stuff
+
+### Old version
+
+This line ends with a tab.	
+And this is a new line.
+   
+previous line contains spaces.

--- a/openformats/tests/formats/github_markdown/files/2_tpl.md
+++ b/openformats/tests/formats/github_markdown/files/2_tpl.md
@@ -1,0 +1,13 @@
+---
+title: 9a1c7ee2c7ce38d4bbbaf29ab9f2ac1e_tr
+
+---
+
+# 3afcdbfeb6ecfbdd0ba628696e3cc163_tr
+
+### 247730f9d0d2eaad265a470e32aa0cdf_tr
+
+cdee9bf40a070d58d14dfa3bb61e0032_tr
+
+7693e302dc09b57483d26522ef25feb4_tr
+

--- a/openformats/tests/formats/github_markdown/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown/test_github_markdown.py
@@ -1,9 +1,16 @@
 import unittest
 
-from openformats.tests.formats.common import CommonFormatTestMixin
 from openformats.formats.github_markdown import GithubMarkdownHandler
+from openformats.tests.formats.common import CommonFormatTestMixin
+from openformats.tests.utils import translate_stringset
 
 
 class GithubMarkdownTestCase(CommonFormatTestMixin, unittest.TestCase):
     HANDLER_CLASS = GithubMarkdownHandler
     TESTFILE_BASE = "openformats/tests/formats/github_markdown/files"
+
+    def test_tabs_in_source_file(self):
+        tmpl, strset = self.handler.parse(self.data["2_en"])
+        translated_strset = translate_stringset(strset)
+        translated_content = self.handler.compile(tmpl, translated_strset)
+        self.assertEquals(translated_content, self.data["2_el"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django==1.5
 polib==1.0.3
-mistune==0.7.3
+mistune==0.7.4

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'polib==1.0.3',
-    'mistune==0.7.3'
+    'mistune==0.7.4'
 ]
 
 tests_require = [


### PR DESCRIPTION
Mistune expands tabs to spaces and removes white characters from blank lines, so we need to do the same so that we are able to match the strings in the original content.