### PR TITLE
Wrap problematic translations in quotes

### DIFF
--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -28,9 +28,9 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         return any([
             self.NEWLINE in tr_string[:-1],
             self.COLON in tr_string,
-            tr_string.startswith(self.ASTERISK),
-            tr_string.startswith(self.AMPERSAND),
-            tr_string.startswith(self.DASH),
+            tr_string.lstrip().startswith(self.ASTERISK),
+            tr_string.lstrip().startswith(self.AMPERSAND),
+            tr_string.lstrip().startswith(self.DASH),
         ])
 
     def compile(self, template, stringset, **kwargs):

--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -19,6 +19,19 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
     BACKSLASH = u'\\'
     DOUBLE_QUOTES = u'"'
     NEWLINE = u'\n'
+    COLON = u':'
+    ASTERISK = u'*'
+    AMPERSAND = u'&'
+    DASH = u'-'
+
+    def _should_wrap_in_quotes(self, tr_string):
+        return any([
+            self.NEWLINE in tr_string[:-1],
+            self.COLON in tr_string,
+            tr_string.startswith(self.ASTERISK),
+            tr_string.startswith(self.AMPERSAND),
+            tr_string.startswith(self.DASH),
+        ])
 
     def compile(self, template, stringset, **kwargs):
         # assume stringset is ordered within the template
@@ -31,7 +44,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
                 # if string's key is int this is a markdown string
                 int(string.key)
             except ValueError:
-                if self.NEWLINE in tr_string[:-1]:
+                if self._should_wrap_in_quotes(tr_string):
                     # escape double quotes inside strings
                     tr_string = string.string.replace(
                         self.DOUBLE_QUOTES,

--- a/openformats/tests/formats/github_markdown_v2/files/1_el.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_el.md
@@ -1,35 +1,36 @@
 ---
-title: el:About writing and formatting on GitHub
-intro: el:into text
+title: "el:About writing and formatting on GitHub"
+intro: "el:into text"
 numeric_var: 12.5
 
 # one comment
 
 key1:
   - list_key:
-    - el:li within li
+    - "el:li within li"
       # second comment
-    - el:li within li 2
-  - el:li 2
+    - "el:li within li 2"
+  - "el:li 2"
 key2:
-  - object_within_list: el:value
-  - el:li 4
-  - el:li 5
+  - object_within_list: "el:value"
+  - "el:li 4"
+  - "el:li 5"
 
-description: el:folded style text
+description: "el:folded style text
+"
 custom_vars:
-  var1: el:some value
+  var1: "el:text: some value"
   var2: "el:literal
 style with \"quotes\"
 text
 "
 nested_key_outer:
   nested_key_inner:
-    el:nested_value
+    "el:nested_value"
 
-key.with.dots: el:dot value
+key.with.dots: "el:dot value"
 
-1: el:integer key
+1: "el:integer key"
 
 ---
 

--- a/openformats/tests/formats/github_markdown_v2/files/1_en.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en.md
@@ -21,7 +21,7 @@ description: >
   style
   text
 custom_vars:
-  var1: some value
+  var1: "text: some value"
   var2: |
     literal
     style with "quotes"

--- a/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
@@ -18,7 +18,7 @@ key2:
 
 description: folded style text
 custom_vars:
-  var1: some value
+  var1: "text: some value"
   var2: "literal
 style with \"quotes\"
 text


### PR DESCRIPTION
Github markdown header is parsed a yaml document. Characters `:`, `&`, `*` and `-` have special meaning in a yaml file so the translations that contain them should be wrapped in double quotes. 