### PR TITLE
Handle 'DOS' newline type in markdown format

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -6,6 +6,7 @@ from mistune import (BlockLexer, Markdown)
 from ..handlers import Handler
 from ..strings import OpenString
 from ..utils.compilers import OrderedCompilerMixin
+from ..utils.newlines import find_newline_type, force_newline_type
 
 
 def string_handler(token, template):
@@ -177,6 +178,10 @@ class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
 
     def parse(self, content, **kwargs):
 
+        newline_type = find_newline_type(content)
+        if newline_type == 'DOS':
+            content = force_newline_type(content, 'UNIX')
+
         template = content
         stringset = []
 
@@ -214,4 +219,4 @@ class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
                 )
                 curr_pos = template.find(string_object.template_replacement)
                 curr_pos = curr_pos + len(string_object.template_replacement)
-        return template, stringset
+        return force_newline_type(template, newline_type), stringset

--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -8,6 +8,7 @@ from openformats.formats.yaml import YamlHandler
 from ..handlers import Handler
 from ..strings import OpenString
 from ..utils.compilers import OrderedCompilerMixin
+from ..utils.newlines import find_newline_type, force_newline_type
 from ..transcribers import Transcriber
 
 
@@ -71,6 +72,10 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         return compiled
 
     def parse(self, content, **kwargs):
+        newline_type = find_newline_type(content)
+        if newline_type == 'DOS':
+            content = force_newline_type(content, 'UNIX')
+
         # mistune expands tabs to 4 spaces and trims trailing spaces, so we
         # need to do the same in order to be able to match the substrings
         template = content.expandtabs(4)
@@ -124,4 +129,4 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
                 curr_pos = curr_pos + len(string_object.template_replacement)
 
         template = yaml_template + seperator + md_template
-        return template, stringset
+        return force_newline_type(template, newline_type), stringset

--- a/openformats/utils/newlines.py
+++ b/openformats/utils/newlines.py
@@ -1,0 +1,17 @@
+def find_newline_type(content):
+    try:
+        first_newline_pos = content.index('\n')
+    except ValueError:
+        return 'UNIX'
+    else:
+        if first_newline_pos > 0 and content[first_newline_pos - 1] == '\r':
+            return 'DOS'
+        else:
+            return 'UNIX'
+
+
+def force_newline_type(content, newline_type):
+    new_content = content.replace('\r\n', '\n')
+    if newline_type == 'DOS':
+        new_content = new_content.replace('\n', '\r\n')
+    return new_content


### PR DESCRIPTION
Related to [TX-8615](https://transifex.atlassian.net/browse/TX-8615)

The issue was that if a string had a DOS-type newline inside it, the
library would extract a string with a UNIX-type newline. So, when the
time came to replace the occurrences with the hashes, the handler
wouldn't find a match and the whole string would be left in the
template. When the time came to compile, the hash wouldn't be found and
so the whole process would fail.

To solve this, at the top of the `parse` method, we detect the newline
type and store it in a variable, then we convert the whole input to use
UNIX-style newlines, thus ensuring that the extracted strings will match
the ones in the input. At the end, we convert the whole template to use
the initial newline type, so that the template is consistent with the
original input.

A similar approach is applied semi-automatically when the Transcriber is
used.