### PR TITLE
TX-8671 Parse strings with custom plural values (e.g. =1) as non-pluralized

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -187,6 +187,21 @@ class JsonHandler(Handler):
             e.g. 'one { I ate {count} apple. } other { I ate {count} apples. }'
         :return: A pluralized OpenString instance or None
         """
+        # The official plurals format supports defining an integer instead
+        # of the name of the plural rule, using a syntax like "=1" or "=2"
+        # We do not support this at the moment, but we want to have these
+        # strings be handled as non pluralized.
+        equality_item = (
+            pyparsing.Literal('=') + pyparsing.Word(pyparsing.alphanums) +
+            pyparsing.nestedExpr('{', '}')
+        )
+        equality_matches = pyparsing.originalTextFor(equality_item)\
+            .searchString(serialized_strings)
+
+        # If any match is found using this syntax, do not parse this
+        # as pluralized
+        if len(equality_matches) > 0:
+            return None
 
         # Each item should be like '<proper_plurality_rule_str> {<content>}'
         # Nested braces ({}) inside <content> are allowed.

--- a/openformats/tests/formats/keyvaluejson/files/1_el.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_el.json
@@ -8,5 +8,6 @@
       "going_on": "el:Something is going on.",
       "wrong": "{ sth, plural, one {el:Something is wrong.} other {el:Somethings are wrong.} }"
     }
-  }
+  },
+  "custom_plural_value": "el:{number, plural, =1 {1 New}, =2 {# New}}"
 }

--- a/openformats/tests/formats/keyvaluejson/files/1_en.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_en.json
@@ -8,5 +8,6 @@
       "going_on": "Something is going on.",
       "wrong": "{ sth, plural, one {Something is wrong.} other {Somethings are wrong.} }"
     }
-  }
+  },
+  "custom_plural_value": "{number, plural, =1 {1 New}, =2 {# New}}"
 }

--- a/openformats/tests/formats/keyvaluejson/files/1_tpl.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_tpl.json
@@ -8,5 +8,6 @@
       "going_on": "38eb89d2562cc44ff2061a045b05ebca_tr",
       "wrong": "{ sth, plural, a125aead7129e03261500e0cade68557_pl }"
     }
-  }
+  },
+  "custom_plural_value": "ee829fd77061d65f1f18982a577b915b_tr"
 }


### PR DESCRIPTION
https://transifex.atlassian.net/browse/TX-8671

If a string defines custom plural values (e.g. `=0`, `=1`, etc) instead of one of the supported plural ids (`zero`, `one`, etc), we now tread that string as non-pluralized.