### PR TITLE
Fix markdown translation file compiling error.

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -182,6 +182,12 @@ class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
         if newline_type == 'DOS':
             content = force_newline_type(content, 'UNIX')
 
+        # mistune expands tabs to 4 spaces and trims trailing spaces, so we
+        # need to do the same in order to be able to match the substrings
+        template = content.expandtabs(4)
+        pattern = re.compile(r'^ +$', re.M)
+        content = pattern.sub('', template)
+
         template = content
         stringset = []
 

--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -80,7 +80,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         # need to do the same in order to be able to match the substrings
         template = content.expandtabs(4)
         pattern = re.compile(r'^ +$', re.M)
-        template = pattern.sub('', template)
+        content = pattern.sub('', template)
 
         stringset = []
 

--- a/openformats/tests/formats/github_markdown/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown/test_github_markdown.py
@@ -7,3 +7,10 @@ from openformats.formats.github_markdown import GithubMarkdownHandler
 class GithubMarkdownTestCase(CommonFormatTestMixin, unittest.TestCase):
     HANDLER_CLASS = GithubMarkdownHandler
     TESTFILE_BASE = "openformats/tests/formats/github_markdown/files"
+
+    def test_parse(self):
+        """Test parse converts tabs to spaces"""
+
+        content_with_tab = self.handler.parse(content=u"# foo	bar")
+        content_with_spaces = self.handler.parse(content=u"# foo    bar")
+        self.assertEqual(content_with_tab[0], content_with_spaces[0])

--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -23,3 +23,9 @@ class GithubMarkdownV2TestCase(CommonFormatTestMixin, unittest.TestCase):
         """Test that import-export is the same as the original file."""
         remade_orig_content = self.handler.compile(self.tmpl, self.strset)
         self.assertEquals(remade_orig_content, self.data["1_en_export"])
+
+    def test_parse(self):
+        """Test parse converts tabs to spaces"""
+        content_with_tab = self.handler.parse(content=u"# foo	bar")
+        content_with_spaces = self.handler.parse(content=u"# foo    bar")
+        self.assertEqual(content_with_tab[0], content_with_spaces[0])


### PR DESCRIPTION
Will affect both markdown v1 & v2. The problem that solves is the mismatch
of hashes (template replacement) during parsing step and compiling step, due
to inconsistency of handling.