### PR TITLE
Fix parsing bug with pluralized entries that include single quotes

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -205,9 +205,18 @@ class JsonHandler(Handler):
 
         # Each item should be like '<proper_plurality_rule_str> {<content>}'
         # Nested braces ({}) inside <content> are allowed.
+        #
+        # Note:
+        # Be sure to ignore single quotes ('), otherwise strings that include
+        # one quote in one plural and another one in another plural, will be
+        # parsed as pluralized but with less rules than they actually have.
+        # (matching will actually include content from multiple rules combined,
+        # instead of separating the content per rule). This seems like a
+        # pyparsing bug. Any other character that could be a potential
+        # separator doesn't seem cause any problem.
         valid_plural_item = (
             pyparsing.oneOf(self.PLURAL_KEYS_STR) +
-            pyparsing.nestedExpr('{', '}')
+            pyparsing.nestedExpr('{', '}', ignoreExpr=pyparsing.Literal("'"))
         )
 
         # We need to make sure that the plural rules are valid.
@@ -216,7 +225,7 @@ class JsonHandler(Handler):
         # we got above.
         any_plural_item = (
             pyparsing.Word(pyparsing.alphanums) +
-            pyparsing.nestedExpr('{', '}')
+            pyparsing.nestedExpr('{', '}', ignoreExpr=pyparsing.Literal("'"))
         )
 
         all_matches = pyparsing.originalTextFor(any_plural_item).searchString(

--- a/openformats/tests/formats/keyvaluejson/files/1_el.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_el.json
@@ -1,6 +1,7 @@
 {
   "singular_key": "el:This is a regular string.",
   "total_files": "{ item_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
+  "special_chars": "{ cnt, plural, one {el:This is Sam's book.} other {el:These are Sam's books.} }",
   "gold_coins": "{ count, plural, zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} }",
   "something": {
     "else": "el:Something else",

--- a/openformats/tests/formats/keyvaluejson/files/1_en.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_en.json
@@ -1,6 +1,7 @@
 {
   "singular_key": "This is a regular string.",
   "total_files": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
+  "special_chars": "{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }",
   "gold_coins": "{ count, plural, zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} }",
   "something": {
     "else": "Something else",

--- a/openformats/tests/formats/keyvaluejson/files/1_tpl.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_tpl.json
@@ -1,6 +1,7 @@
 {
   "singular_key": "ab2800d7ccb83ba2d643174531d08e36_tr",
   "total_files": "{ item_count, plural, 9af043f75968a7df63dfa2b27c57e2dc_pl }",
+  "special_chars": "{ cnt, plural, 00fe762ad9b56187fed536350bc3a40c_pl }",
   "gold_coins": "{ count, plural, 8060865280cf7fc9e80b79145208a825_pl }",
   "something": {
     "else": "27fc99812beff2126b12708a336513c8_tr",


### PR DESCRIPTION
Pluralized strings that had 2 single quotes, one in one plural content and the other in another plural content, would not be parsed properly. 

Failing strings looked like:
`"{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }"`

This would be parsed as `pluralized=true`, but with only the `one` plural form, which would contain a much bigger string as a translation: `"{This is Sam's book.} other {These are Sam's books.}"`, which would result to a wrong pluralized string:

```
{
    "one": "{This is Sam's book.} other {These are Sam's books.}"
}
```

instead of the proper value:

```
{
    "one": "{This is Sam's book.}",
    "other": "{These are Sam's books.}"
}
```


Note that if there was only one single quote (e.g. inside the translation of `one`), the string was parsed successfully.