### PR TITLE
TX-8836 Allow newline chars in certain places of plural strings

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -308,11 +308,19 @@ class JsonHandler(Handler):
 
         :raise: ParseError
         """
+        # Replace all matches with spaces in the given string.
         remaining_str = serialized_strings
         for match in all_matches:
             remaining_str = remaining_str.replace(match[0], '')
 
-        if len(remaining_str.strip()) > 0:
+        # Then make sure all whitespace is removed as well
+        # Special characters may be present with double backslashes,
+        # e.g. \\n
+        remaining_str = remaining_str.replace('\\n', '\n')\
+            .replace('\\t', '\t')\
+            .strip()
+
+        if len(remaining_str) > 0:
             raise ParseError(
                 'Invalid format of pluralized entry '
                 'with key: "{}", serialized translations: "{}". '

--- a/openformats/tests/formats/keyvaluejson/files/1_el.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_el.json
@@ -2,7 +2,7 @@
   "singular_key": "el:This is a regular string.",
   "total_files": "{ item_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
   "special_chars": "{ cnt, plural, one {el:This is Sam's book.} other {el:These are Sam's books.} }",
-  "gold_coins": "{ count, plural, zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} }",
+  "gold_coins": "{ count, plural,\n zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} \n}",
   "something": {
     "else": "el:Something else",
     "is": {

--- a/openformats/tests/formats/keyvaluejson/files/1_en.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_en.json
@@ -2,7 +2,7 @@
   "singular_key": "This is a regular string.",
   "total_files": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
   "special_chars": "{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }",
-  "gold_coins": "{ count, plural, zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} }",
+  "gold_coins": "{ count, plural,\n zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} \n}",
   "something": {
     "else": "Something else",
     "is": {

--- a/openformats/tests/formats/keyvaluejson/files/1_tpl.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_tpl.json
@@ -2,7 +2,7 @@
   "singular_key": "ab2800d7ccb83ba2d643174531d08e36_tr",
   "total_files": "{ item_count, plural, 9af043f75968a7df63dfa2b27c57e2dc_pl }",
   "special_chars": "{ cnt, plural, 00fe762ad9b56187fed536350bc3a40c_pl }",
-  "gold_coins": "{ count, plural, 8060865280cf7fc9e80b79145208a825_pl }",
+  "gold_coins": "{ count, plural,\n 8060865280cf7fc9e80b79145208a825_pl \n}",
   "something": {
     "else": "27fc99812beff2126b12708a336513c8_tr",
     "is": {

--- a/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
@@ -454,6 +454,23 @@ class JsonTestCase(CommonFormatTestMixin, unittest.TestCase):
             expected_translations
         )
 
+        # Escaped new lines should be allowed
+        self._test_translations_equal(
+            '{'
+            '    "k": "{cnt, plural,\\n zero {Empty} other {{count} files} \\n}"'  #noqa
+            '}',
+            expected_translations
+        )
+
+        # Renderind a template with escaped new lines should work. However,
+        # these characters cannot be inside the pluralized string, because the
+        # template would be very hard to create in that case (e.g. not allowed
+        # in: 'zero {Empty} \n other {{count} files}'
+        source = '{"a": "{cnt, plural,\\n one {0} other {{count} files} \\n}"}'
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, stringset)
+        self.assertEquals(compiled, source)
+
     def test_nesting_with_plurals(self):
         expected_translations = {0: 'Empty', 5: '{count} files'}
 


### PR DESCRIPTION
https://transifex.atlassian.net/browse/TX-8836

This refers to the plurals in the KEYVALUEJSON format. In particular, newline characters should be allowed in certain places of the serialized string. 
For example, the following should be allowed:

```
{
  "message": "{cnt, plural,\n zero {Empty} other {{count} files} \n}"
}
```

but it threw an error before this PR. This PR allows newline characters in cases like this.

Note, however, that any newline characters that are inside inside the "content" part of the pluralized string will be removed from the template, and thus from the rendered file, when downloaded from Transifex.

For example, the following:
(note `\n` somewhere between `zero` and `other`)

```
{
  "message": "{cnt, plural,\n zero {Empty} \n other {{count} files} \n}"
}
```

will become:

```
{
  "message": "{cnt, plural,\n zero {Empty} other {{count} files} \n}"
}
```

The reason is that we cannot create a template that allows anything inside the string hash. In the case above, the template would look like:

```
{
  "message": "{cnt, plural,\n 8060865280cf7fc9eu3829145208a825_pl \n}"
}
```
and there is no way to know that an irrelevant character (`\n`) was somewhere inside the part that now has the string hash.