### PR TITLE
Skips replacement for fences inside list_blocks

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -215,7 +215,7 @@ class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
         curr_pos = 0
         for string in (yaml_stringset + block.md_stringset):
             string = string_handler(string, template)
-            if string:
+            if string and string in template[curr_pos:]:
                 string_object = OpenString(str(order), string, order=order)
                 order += 1
                 stringset.append(string_object)

--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -117,7 +117,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         curr_pos = 0
         for string in block.md_stringset:
             string = string_handler(string, md_template)
-            if string:
+            if string and string in template[curr_pos:]:
                 string_object = OpenString(str(order), string, order=order)
                 order += 1
                 stringset.append(string_object)

--- a/openformats/tests/formats/github_markdown/files/1_el.md
+++ b/openformats/tests/formats/github_markdown/files/1_el.md
@@ -38,6 +38,9 @@ el:_You **can** combine bold and italic_
 * el:Item 2
   * el:Item 2a
   * el:Item 2b
+  * ```
+    Item 2c
+    ```
 
 ### el:Ordered
 
@@ -46,6 +49,9 @@ el:_You **can** combine bold and italic_
 1. el:Item 3
    1. el:Item 3a
    1. el:Item 3b
+   1. ```
+      Item 3c
+      ```
 
 
 ## el:Images

--- a/openformats/tests/formats/github_markdown/files/1_en.md
+++ b/openformats/tests/formats/github_markdown/files/1_en.md
@@ -38,6 +38,9 @@ _You **can** combine bold and italic_
 * Item 2
   * Item 2a
   * Item 2b
+  * ```
+    Item 2c
+    ```
 
 ### Ordered
 
@@ -46,6 +49,9 @@ _You **can** combine bold and italic_
 1. Item 3
    1. Item 3a
    1. Item 3b
+   1. ```
+      Item 3c
+      ```
 
 
 ## Images

--- a/openformats/tests/formats/github_markdown/files/1_tpl.md
+++ b/openformats/tests/formats/github_markdown/files/1_tpl.md
@@ -34,6 +34,9 @@ custom_vars:
 * 26101031d5115f57d3e8c34f2ac1f741_tr
   * ac435aa88d7932bc7c26dbe0277119a3_tr
   * 311a0516b1c6eb11a28e8deaa5c64c78_tr
+  * ```
+    Item 2c
+    ```
 
 ### a3575631fc76819748da773b5b0087a4_tr
 
@@ -42,6 +45,9 @@ custom_vars:
 1. 867da7e2af8e6b2f3aa7213a4080edb3_tr
    1. a6c1243676462dae35ed0c9122125d4e_tr
    1. 6994d1415b92982eb7cf57740b15b949_tr
+   1. ```
+      Item 3c
+      ```
 
 
 ## 061c16448aee6be07e20ab574ef27ea4_tr

--- a/openformats/tests/formats/github_markdown_v2/files/1_el.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_el.md
@@ -57,6 +57,9 @@ el:_You **can** combine bold and italic_
 * el:Item 2
   * el:Item 2a
   * el:Item 2b
+  * ```
+    Item 2c
+    ```
 
 ### el:Ordered
 
@@ -65,6 +68,9 @@ el:_You **can** combine bold and italic_
 1. el:Item 3
    1. el:Item 3a
    1. el:Item 3b
+   1. ```
+      Item 3c
+      ```
 
 
 ## el:Images

--- a/openformats/tests/formats/github_markdown_v2/files/1_en.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en.md
@@ -60,6 +60,9 @@ _You **can** combine bold and italic_
 * Item 2
   * Item 2a
   * Item 2b
+  * ```
+    Item 2c
+    ```
 
 ### Ordered
 
@@ -68,6 +71,9 @@ _You **can** combine bold and italic_
 1. Item 3
    1. Item 3a
    1. Item 3b
+   1. ```
+      Item 3c
+      ```
 
 
 ## Images

--- a/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
@@ -56,6 +56,9 @@ _You **can** combine bold and italic_
 * Item 2
   * Item 2a
   * Item 2b
+  * ```
+    Item 2c
+    ```
 
 ### Ordered
 
@@ -64,6 +67,9 @@ _You **can** combine bold and italic_
 1. Item 3
    1. Item 3a
    1. Item 3b
+   1. ```
+      Item 3c
+      ```
 
 
 ## Images

--- a/openformats/tests/formats/github_markdown_v2/files/1_tpl.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_tpl.md
@@ -51,6 +51,9 @@ a3575631fc76819748da773b5b0087a4_tr
 * 061c16448aee6be07e20ab574ef27ea4_tr
   * ea8a5a340cab600d88eea120273c4022_tr
   * 944024165d37855a16b48158a491e0a5_tr
+  * ```
+    Item 2c
+    ```
 
 ### d51c2a7526e97b2e9ba2d86ac075af7c_tr
 
@@ -59,6 +62,9 @@ a3575631fc76819748da773b5b0087a4_tr
 1. f1c3d12b026ece333653621093d9abe3_tr
    1. bb74ac206332955a7b4f5076f55b2e26_tr
    1. bc3bd100ff8a56464a05d8f7f8bb7a6d_tr
+   1. ```
+      Item 3c
+      ```
 
 
 ## 28e677da01f23106bbe6f32634edae27_tr


### PR DESCRIPTION
Problem
-------
Compilation for markdown that includes fences (code blocks) inside list blocks fails.
This is due to inconsistency created on the parsing step, where the template replacement
is failing to match extracted fences from the template, with those that actually exist 
in the template.

Steps to reproduce
------------------
Parse and compile the following md template:
<pre>
1. List
   1. ```
      code
      ```
</pre>

Solution
--------
Skips template replacement when extracted substring cannot be found on template.