### PR TITLE
[DNM] Yaml standalone

### DIFF
--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -59,7 +59,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
                 # this is to ensure that if the style is literal or folded
                 # http://www.yaml.org/spec/1.2/spec.html#id2795688
                 # a new line always follows the string
-                if (string.flags and string.flags in '|>' and
+                if (string.flags and string.flags[-1] in '|>' and
                         tr_string[-1] != self.NEWLINE):
                     tr_string = tr_string + self.NEWLINE
 
@@ -96,7 +96,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
             yaml_header_content = ''.join(yml_header.group(1, 2))
             seperator = yml_header.group(3)
             md_content = content[len(yaml_header_content + seperator):]
-            yaml_stringset, yaml_template = YamlHandler().parse(
+            yaml_template, yaml_stringset = YamlHandler().parse(
                 yaml_header_content)
         else:
             md_content = content

--- a/openformats/formats/yaml.py
+++ b/openformats/formats/yaml.py
@@ -14,7 +14,7 @@ from ..transcribers import Transcriber
 
 class YamlHandler(Handler):
     name = "Yaml"
-    extension = ".yml"
+    extension = "yml"
     EXTRACTS_RAW = False
 
     BACKSLASH = u'\\'

--- a/openformats/formats/yaml.py
+++ b/openformats/formats/yaml.py
@@ -19,12 +19,14 @@ class YamlHandler(Handler):
 
     BACKSLASH = u'\\'
     DOUBLE_QUOTES = u'"'
+    SINGLE_QUOTES = u'\''
     NEWLINE = u'\n'
     COLON = u':'
     ASTERISK = u'*'
     AMPERSAND = u'&'
     DASH = u'-'
     HASHTAG = u'#'
+    BACKTICK = u'`'
 
     def _should_wrap_in_quotes(self, tr_string):
         return any([
@@ -34,6 +36,9 @@ class YamlHandler(Handler):
             tr_string.lstrip().startswith(self.ASTERISK),
             tr_string.lstrip().startswith(self.AMPERSAND),
             tr_string.lstrip().startswith(self.DASH),
+            tr_string.lstrip().startswith(self.SINGLE_QUOTES),
+            tr_string.lstrip().startswith(self.BACKTICK),
+            tr_string.rstrip().endswith(self.BACKTICK),
         ])
 
     def _wrap_in_quotes(self, tr_string):

--- a/openformats/formats/yaml.py
+++ b/openformats/formats/yaml.py
@@ -9,9 +9,54 @@ from yaml.constructor import ConstructorError
 from ..handlers import Handler
 from ..strings import OpenString
 from ..exceptions import ParseError
+from ..transcribers import Transcriber
 
 
 class YamlHandler(Handler):
+    name = "Yaml"
+    extension = ".yml"
+    EXTRACTS_RAW = False
+
+    BACKSLASH = u'\\'
+    DOUBLE_QUOTES = u'"'
+    NEWLINE = u'\n'
+    COLON = u':'
+    ASTERISK = u'*'
+    AMPERSAND = u'&'
+    DASH = u'-'
+    HASHTAG = u'#'
+
+    def _should_wrap_in_quotes(self, tr_string):
+        return any([
+            self.NEWLINE in tr_string[:-1],
+            self.COLON in tr_string,
+            self.HASHTAG in tr_string,
+            tr_string.lstrip().startswith(self.ASTERISK),
+            tr_string.lstrip().startswith(self.AMPERSAND),
+            tr_string.lstrip().startswith(self.DASH),
+        ])
+
+    def _wrap_in_quotes(self, tr_string):
+        if self._should_wrap_in_quotes(tr_string):
+            # escape double quotes inside strings
+            tr_string = tr_string.replace(
+                self.DOUBLE_QUOTES,
+                (self.BACKSLASH + self.DOUBLE_QUOTES)
+            )
+            # surround string with double quotes
+            tr_string = (self.DOUBLE_QUOTES + tr_string +
+                         self.DOUBLE_QUOTES)
+        return tr_string
+
+    def _compile_single(self, string):
+        tr_string = self._wrap_in_quotes(string.string)
+        # this is to ensure that if the style is literal or folded
+        # http://www.yaml.org/spec/1.2/spec.html#id2795688
+        # a new line always follows the string
+        if (string.flags and string.flags in '|>' and
+                tr_string[-1] != self.NEWLINE):
+            tr_string = tr_string + self.NEWLINE
+        return tr_string
 
     def _load_yaml(self, content, loader):
         """
@@ -30,7 +75,8 @@ class YamlHandler(Handler):
         except yaml.scanner.ScannerError as e:
             raise ParseError(unicode(e))
 
-    def _parse_leaf_node(self, yaml_data, parent_key, style=[]):
+    def _parse_leaf_node(self, yaml_data, parent_key, style=[],
+                         pluralized=False):
         """Parse a leaf node in yaml_dict.
         Args:
             yaml_data: A tuple of the form (string, start, end, style)
@@ -42,7 +88,8 @@ class YamlHandler(Handler):
         Returns:
             A dictionary representing the parsed leaf node
         """
-        value = yaml_data[0]
+        val = yaml_data[0]
+        value = self.parse_pluralized_value(val) if pluralized else val
         start = yaml_data[1]
         end = yaml_data[2]
         style.append(yaml_data[3] or '')
@@ -51,11 +98,14 @@ class YamlHandler(Handler):
             'end': end,
             'key': parent_key,
             'value': value,
-            'style': ':'.join(style or [])
+            'style': ':'.join(style or []),
+            'pluralized': pluralized,
         }
 
     @staticmethod
     def unescape_dots(k):
+        """ We use dots to construct the strings key, so we need to
+        escape dots that are part of an actual YAML key """
         return k.replace('.', '<TX_DOT>')
 
     def _get_key_for_node(self, key, parent_key):
@@ -103,8 +153,20 @@ class YamlHandler(Handler):
             for key, val in yaml_data.items():
                 node_key = self._get_key_for_node(key, parent_key)
                 style = copy.copy(parent_style)
-                if isinstance(val[0], (dict, list)):
-                    # style.append(val.get('style', ''))
+                if isinstance(val[0], dict):
+                    if self.is_pluralized(val[0]):
+                        parsed_data.append(
+                            self._parse_leaf_node(
+                                val, node_key,
+                                style=copy.copy(parent_style or []),
+                                pluralized=True
+                            )
+                        )
+                    else:
+                        parsed_data = self.parse_yaml_data(
+                            val[0], node_key, parsed_data, context,
+                            parent_style=copy.copy(style or []))
+                elif isinstance(val[0], list):
                     parsed_data = self.parse_yaml_data(
                         val[0], node_key, parsed_data, context,
                         parent_style=copy.copy(style or []))
@@ -119,15 +181,15 @@ class YamlHandler(Handler):
             # using the position (index) of it as parent key using
             # brackets around it. I.e.: 'foo.[0].bar'.
             for i, e in enumerate(yaml_data):
-                p_key = parent_key + '.[%s]' % (i)
+                node_key = self._get_key_for_node('[%s]' % (i), parent_key)
                 if isinstance(e, (dict, list)):
                     parsed_data = self.parse_yaml_data(
-                        e, p_key, parsed_data, context,
+                        e, node_key, parsed_data, context,
                         parent_style=copy.copy(parent_style or []))
                 else:
                     parsed_data.append(
                         self._parse_leaf_node(
-                            e, p_key, style=copy.copy(parent_style or [])
+                            e, node_key, style=copy.copy(parent_style or [])
                         )
                     )
         else:
@@ -162,12 +224,47 @@ class YamlHandler(Handler):
         else:
             return None
 
+    def get_yaml_data_to_parse(self, yaml_data):
+        """ Returns the part of the yaml_data that actually need to be parsed
+
+        In some cases only a part of the YAML structure needs to be
+        processed for strings to be extracted. e.g. when the root key is the
+        language code we need to exclude this from the rest of the processing.
+        In the generic case the whole structure will be processed.
+        """
+        return yaml_data
+
     def parse(self, content, **kwargs):
+        """ Parses the given YAML content to create stringset and template
+
+        Steps are:
+            1. Load yaml content using our custom loader TxYamlLoader that
+               in addition to the value for each key notes the `start` and
+               `end` index of each node in the file and some metadata.
+            2. Flattens the output of the loader to be a list of the form:
+               ```
+               [{
+                   'key': 'string_key1',
+                   'value': 'string1',
+                   'end': <end_index_of_node>,
+                   'start': <start_index_value>,
+                   'style': '|, >, ...'
+                },
+                ...
+               ]
+               ```
+            3. Iterates over the flattened list and for each entry creates an
+               OpenString object, appends it to stringset and replace its value
+               with the template_replacement in the template.
+            4. Returns the (template, stringset) tuple.
+        """
         template = ""
         context = ""
         stringset = []
         yaml_data = self._load_yaml(content, loader=TxYamlLoader)
-        parsed_data = self.parse_yaml_data(yaml_data, '', [], context)
+        yaml_data = self.get_yaml_data_to_parse(yaml_data)
+        parsed_data = self.parse_yaml_data(yaml_data, '', [],
+                                           context)
         parsed_data.sort()
 
         end = 0
@@ -192,7 +289,55 @@ class YamlHandler(Handler):
             end = end_
 
         template += content[end:]
-        return stringset, template
+        return template, stringset
+
+    def compile(self, template, stringset, **kwargs):
+        """ Compiles translation file from template
+
+        Iterates over the stringset and for each strings replaces
+        template replacement in the template with the actual translation.
+
+        Returns the compiled file content.
+        """
+        transcriber = Transcriber(template)
+        template = transcriber.source
+
+        for string in stringset:
+            if string.pluralized:
+                tr_string = self._compile_pluralized(string)
+            else:
+                tr_string = self._compile_single(string)
+            hash_position = template.index(string.template_replacement)
+            transcriber.copy_until(hash_position)
+            transcriber.add(tr_string)
+            transcriber.skip(len(string.template_replacement))
+
+        transcriber.copy_until(len(template))
+        compiled = transcriber.get_destination()
+
+        return compiled
+
+    def _compile_pluralized(self, string):
+        """ Prepare a pluralized string to be added to the template
+        """
+        raise NotImplemented
+
+    def parse_pluralized_value(self, value):
+        """ Creates a dictionary of the form:
+        ```
+        {rule_number: rule_translation, ...}
+        ```
+        based on a YAML node """
+        raise NotImplemented
+
+    def is_pluralized(self, val):
+        """ Checks if given yml node should be handled as pluralized
+
+        This method by default returns False because no entry in a
+        generic YML file should be handled as pluralized.
+        Should be overriden in any subclass that should handle pluralized
+        strings """
+        return False
 
 
 class TxYamlLoader(yaml.SafeLoader):

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -1,0 +1,33 @@
+---
+title: "el:About writing and formatting on GitHub"
+intro: "el:into text"
+numeric_var: 12.5
+
+# one comment
+
+key1:
+  - list_key:
+    - "el:li within li"
+      # second comment
+    - "el:li within li 2"
+  - "el:li 2"
+key2:
+  - object_within_list: "el:value"
+  - "el:text with a #hashtag in it"
+  - "el:li 5"
+
+description: "el:folded style text
+"
+custom_vars:
+  var1: "el:text: some value"
+  var2: "el:literal
+style with \"quotes\"
+text
+"
+nested_key_outer:
+  nested_key_inner:
+    "el:nested_value"
+
+key.with.dots: "el:dot value"
+
+1: "el:integer key"

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -31,3 +31,7 @@ nested_key_outer:
 key.with.dots: "el:dot value"
 
 1: "el:integer key"
+
+value with quote: "el:'value"
+value with start backtick: "el:`value"
+value with end backtick: "el:value`"

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -1,0 +1,36 @@
+---
+title: About writing and formatting on GitHub
+intro: into text
+numeric_var: 12.5
+
+# one comment
+
+key1:
+  - list_key:
+    - li within li
+      # second comment
+    - li within li 2
+  - li 2
+key2:
+  - object_within_list: value
+  - "text with a #hashtag in it"
+  - li 5
+
+description: >
+  folded
+  style
+  text
+custom_vars:
+  var1: "text: some value"
+  var2: |
+    literal
+    style with "quotes"
+    text
+
+nested_key_outer:
+  nested_key_inner:
+    nested_value
+
+key.with.dots: dot value
+
+1: integer key

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -34,3 +34,7 @@ nested_key_outer:
 key.with.dots: dot value
 
 1: integer key
+
+value with quote: "'value"
+value with start backtick: "`value"
+value with end backtick: "value`"

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -1,0 +1,36 @@
+---
+title: About writing and formatting on GitHub
+intro: into text
+numeric_var: 12.5
+
+# one comment
+
+key1:
+  - list_key:
+    - li within li
+      # second comment
+    - li within li 2
+  - li 2
+key2:
+  - object_within_list: value
+  - "text with a #hashtag in it"
+  - li 5
+
+description: >
+  folded
+  style
+  text
+custom_vars:
+  var1: "text: some value"
+  var2: |
+    literal
+    style with "quotes"
+    text
+
+nested_key_outer:
+  nested_key_inner:
+    nested_value
+
+key.with.dots: dot value
+
+1: integer key

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -16,17 +16,13 @@ key2:
   - "text with a #hashtag in it"
   - li 5
 
-description: >
-  folded
-  style
-  text
+description: folded style text
 custom_vars:
   var1: "text: some value"
-  var2: |
-    literal
-    style with "quotes"
-    text
-
+  var2: "literal
+style with \"quotes\"
+text
+"
 nested_key_outer:
   nested_key_inner:
     nested_value

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -30,3 +30,7 @@ nested_key_outer:
 key.with.dots: dot value
 
 1: integer key
+
+value with quote: "'value"
+value with start backtick: "`value"
+value with end backtick: "value`"

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -1,0 +1,27 @@
+---
+title: 6391362253bdac99fff7bf50ff014be3_tr
+intro: e8c07422d0167fee3ecf8f3375ea5739_tr
+numeric_var: 12.5
+
+# one comment
+
+key1:
+  - list_key:
+    - ac56af108b4b69b867c09f8542a51cb2_tr
+      # second comment
+    - d2d20cce249c5d7e8ca96b9e30a3349c_tr
+  - 17e2086737d2192e6665ea2c0f0b1e9a_tr
+key2:
+  - object_within_list: 1a397fe7999e432441bfce7a1f4fb1f3_tr
+  - aa8c6113a4236d576f96ba9b0bd4dfa4_tr
+  - 76d7c5ccc4301f10b39115b2c1a9ca47_tr
+
+description: fdba4efe4ab9d38afee4054a7fa06e29_trcustom_vars:
+  var1: 8b9f5508bd423a15a188813d60e52946_tr
+  var2: 7169ba1087c5204f12ab8b7c066884a2_trnested_key_outer:
+  nested_key_inner:
+    94b99ee5f1d082d7df28c4b48aa99ff8_tr
+
+key.with.dots: ddbc5d72cdd64acc258ab3446b6466ed_tr
+
+1: 9354e4f807073d6a146138fe6d81e4ef_tr

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -25,3 +25,7 @@ description: fdba4efe4ab9d38afee4054a7fa06e29_trcustom_vars:
 key.with.dots: ddbc5d72cdd64acc258ab3446b6466ed_tr
 
 1: 9354e4f807073d6a146138fe6d81e4ef_tr
+
+value with quote: 4ea9d14bca65fb09e8b7c2c54ce8fd4e_tr
+value with start backtick: 05cecdb72a9f3d915c749bba5295901c_tr
+value with end backtick: 109530f343dfa59480e0e3aa11816cbb_tr

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -1,0 +1,21 @@
+import unittest
+from os import path
+
+from openformats.tests.formats.common import CommonFormatTestMixin
+from openformats.formats.yaml import YamlHandler
+
+
+class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
+    HANDLER_CLASS = YamlHandler
+    TESTFILE_BASE = "openformats/tests/formats/yaml/files"
+
+    def __init__(self, *args, **kwargs):
+        super(YamlTestCase, self).__init__(*args, **kwargs)
+        filepath = path.join(self.TESTFILE_BASE, "1_en_exported.yml")
+        with open(filepath, "r") as myfile:
+            self.data['1_en_exported'] = myfile.read().decode("utf-8")
+
+    def test_compile(self):
+        """Test that import-export is the same as the original file."""
+        remade_orig_content = self.handler.compile(self.tmpl, self.strset)
+        self.assertEquals(remade_orig_content, self.data["1_en_exported"])


### PR DESCRIPTION
* Make YamlHandler currently used by GithubMarkdownV2Handler a standalone parser.
* Make it aware of pluralized strings and add hooks in order subclasses to be able to handle pluralized strings. (A first version of how the hooks might look like is in https://github.com/transifex/openformats/tree/i18n_yaml where the i18n specific handler will be implemented).

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

Steps to reproduce
------------------

Solution
--------

Example run / Screenshots
-------------------------

Performance on live data
------------------------
