### PR TITLE
Speed up PO compiling when there are a lot of entries to remove

### DIFF
--- a/openformats/formats/po.py
+++ b/openformats/formats/po.py
@@ -111,7 +111,6 @@ class PoHandler(Handler):
             'flags': ', '.join(entry.flags),
             'occurrences': occurrences if occurrences else None,
             'developer_comment': entry_comments,
-            'context': entry.msgctxt if entry.msgctxt else ""
         }
 
         string = self._get_string(entry, pluralized)
@@ -270,7 +269,8 @@ class PoHandler(Handler):
         next_string = next(stringset, None)
 
         po = polib.pofile(template)
-        for entry in list(po):
+        indexes_to_remove = []
+        for i, entry in enumerate(po):
             if next_string is not None:
                 is_plural = True if entry.msgid_plural.strip() else False
                 if is_plural:
@@ -280,7 +280,8 @@ class PoHandler(Handler):
                 if compiled:
                     next_string = next(stringset, None)
                     continue
-            po.remove(entry)
+            indexes_to_remove.append(i)
+        self._smart_remove(po, indexes_to_remove)
         return unicode(po)
 
     def _compile_entry(self, entry, next_string):
@@ -308,6 +309,10 @@ class PoHandler(Handler):
             entry.msgstr_plural = next_string.string
             return True
         return False
+
+    def _smart_remove(self, po, indexes_to_remove):
+        for i in reversed(indexes_to_remove):
+            del po[i]
 
     @staticmethod
     def _format_occurrences(occurrences):


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [ ] N/A Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------

polib implements deserialized po files as subclasses of `list`. Thus,
hen you want to remove an entry, you can either use `.remove` or `del`.
`.remove` (the one we were using so far) does a serial search in the po
file until it finds the entry to remove. If the po file is big and you
are doing lots of removals, this can become unbearable.

Steps to reproduce
------------------

1. Upload a big po file
2. Translate something like 20-30% of it in a language
3. Download via the API using the `onlytranslated` option

```bash
# Using [httpie](http://httpie.org/)
http -a foo:bar 'https://www.transifex.com/api/2/project/foo/resource/bar/translation/el/?mode=onlytranslated'
```

Solution
--------

This implementation instead uses `del`. While iterating through the po
file, we add the indexes of the entries we want to remove in a list.
After the iteration is finished, we go through that list in reverse
order and use `del` to remove the entries. Since `del` does not do a
serial search, it is noticeably faster.

Example run / Screenshots, Performance on live data
---------------------------------------------------

```bash
$ git checkout devel
$ time http -a foo:bar --timeout 3000 ':8002/api/2/project/foo/resource/bar/translation/pt/?mode=onlytranslated'

> http --session=kb_admin --timeout 3000   0.81s user 0.17s system 0% cpu 2:49.19 total

$ git checkout po_speedup
$ time http -a foo:bar --timeout 3000 ':8002/api/2/project/foo/resource/bar/translation/pt/?mode=onlytranslated'

> http --session=kb_admin --timeout 3000   0.85s user 0.17s system 10% cpu 9.698 total
```