### PR TITLE
Remove Jira ticket reference from PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-Related to [TX-XXXX: Paste ticket's title here](https://transifex.atlassian.net/browse/TX-XXXX)
-
 Checklist (for the reviewer)
 ----------------------------
 


### PR DESCRIPTION
Avoid exposing sensitive private information from our Jira board to the public