### PR TITLE
When polib raises an exception, re-raise it as a ParseError

### DIFF
--- a/openformats/formats/po.py
+++ b/openformats/formats/po.py
@@ -30,7 +30,11 @@ class PoHandler(Handler):
         stringset = []
         self.is_source = is_source
         self.order_generator = itertools.count()
-        po = polib.pofile(content)
+        try:
+            po = polib.pofile(content)
+        except Exception, e:
+            raise ParseError("Error while validating PO file syntax: {}".
+                             format(e.message))
         self.only_values = False
         self.only_keys = False
         self.new_po = copy.copy(po)

--- a/openformats/tests/formats/po/test_po.py
+++ b/openformats/tests/formats/po/test_po.py
@@ -1,12 +1,12 @@
 import unittest
 import itertools
 
-from openformats.strings import OpenString
+from openformats.exceptions import ParseError
 from openformats.formats.po import PoHandler
+from openformats.strings import OpenString
 from openformats.tests.formats.common import CommonFormatTestMixin
-from openformats.tests.utils.strings import (
-    strip_leading_spaces, generate_random_string
-)
+from openformats.tests.utils.strings import (strip_leading_spaces,
+                                             generate_random_string)
 
 
 class PoTestCase(CommonFormatTestMixin, unittest.TestCase):
@@ -462,3 +462,8 @@ class PoTestCase(CommonFormatTestMixin, unittest.TestCase):
             u"Incomplete plural forms found on the entry with msgid `p1` "
             u"and msgid_plural `p2`."
         )
+
+    def test_invalid_po_raised_as_parseerror(self):
+        source = "blyargh"
+        with self.assertRaises(ParseError):
+            self.handler.parse(source)


### PR DESCRIPTION
so that:

1. The error message the user gets helps him/her resolve the problem
2. We don't show a 500 error to the user
3. We don't get a report in sentry

Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] N/A Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

The PO handler uses `polib.pofile()` to parse the incoming file. If there are basic problems with the syntax of the po file, then polib will raise a `IOError`. We are supposed to re-raise this as a ParseError so that the error message makes it to the user.

Steps to reproduce
------------------

N/A

Solution
--------

Simple try-catch with a `raise ParseError`

Example run / Screenshots
-------------------------

N/A

Performance on live data
------------------------

N/A
