### PR TITLE
Include all translatable content in Stringsdict format

### DIFF
--- a/openformats/tests/formats/stringsdict/files/1_el.stringsdict
+++ b/openformats/tests/formats/stringsdict/files/1_el.stringsdict
@@ -45,5 +45,48 @@
                 <string>el:Other tests exist.</string>
             </dict>
         </dict>
+        <key>TEST INLINE REPLACEMENT</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@test@</string>
+            <key>test</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>el:There is a mouse in the %#@room@ here</string>
+                <key>other</key>
+                <string>el:There are %d mice in the %#@room@ here</string>
+            </dict>
+            <key>room</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>el:a room</string>
+                <key>other</key>
+                <string>el:%d rooms</string>
+            </dict>
+        </dict>
+        <key>LAST</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@test@</string>
+            <key>test</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>el:One mouse</string>
+                <key>other</key>
+                <string>el:%d mice</string>
+            </dict>
+        </dict>
     </dict>
 </plist>

--- a/openformats/tests/formats/stringsdict/files/1_en.stringsdict
+++ b/openformats/tests/formats/stringsdict/files/1_en.stringsdict
@@ -45,5 +45,48 @@
                 <string>Other tests exist.</string>
             </dict>
         </dict>
+        <key>TEST INLINE REPLACEMENT</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>There %#@test@ in the %#@room@ here</string>
+            <key>test</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>is a mouse</string>
+                <key>other</key>
+                <string>are %d mice</string>
+            </dict>
+            <key>room</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>a room</string>
+                <key>other</key>
+                <string>%d rooms</string>
+            </dict>
+        </dict>
+        <key>LAST</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@test@</string>
+            <key>test</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <key>one</key>
+                <string>One mouse</string>
+                <key>other</key>
+                <string>%d mice</string>
+            </dict>
+        </dict>
     </dict>
 </plist>

--- a/openformats/tests/formats/stringsdict/files/1_tpl.stringsdict
+++ b/openformats/tests/formats/stringsdict/files/1_tpl.stringsdict
@@ -39,5 +39,42 @@
                 <tx_awesome_string_tag>ec8a7a8b22906062781b0aacccacfba3_pl</tx_awesome_string_tag>
             </dict>
         </dict>
+        <key>TEST INLINE REPLACEMENT</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@test@</string>
+            <key>test</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <tx_awesome_key_tag></tx_awesome_key_tag>
+                <tx_awesome_string_tag>f2173da507415303a5346c293fa086bf_pl</tx_awesome_string_tag>
+            </dict>
+            <key>room</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <tx_awesome_key_tag></tx_awesome_key_tag>
+                <tx_awesome_string_tag>5941243ff132731d2655e82adf787f14_pl</tx_awesome_string_tag>
+            </dict>
+        </dict>
+        <key>LAST</key>
+        <dict>
+            <key>NSStringLocalizedFormatKey</key>
+            <string>%#@test@</string>
+            <key>test</key>
+            <dict>
+                <key>NSStringFormatSpecTypeKey</key>
+                <string>NSStringPluralRuleType</string>
+                <key>NSStringFormatValueTypeKey</key>
+                <string>d</string>
+                <tx_awesome_key_tag></tx_awesome_key_tag>
+                <tx_awesome_string_tag>383613b398803eb778f9abac0e8808f0_pl</tx_awesome_string_tag>
+            </dict>
+        </dict>
     </dict>
 </plist>

--- a/openformats/tests/formats/stringsdict/test_stringsdict.py
+++ b/openformats/tests/formats/stringsdict/test_stringsdict.py
@@ -38,6 +38,18 @@ class StringsDictTestCase(CommonFormatTestMixin, unittest.TestCase):
         context_dict['hash'] = openstring.template_replacement
         return context_dict, openstring
 
+    def test_compile(self):
+        """
+        Bypass this test.
+
+        Stringsdict format differs from the rest of the formats since it
+        transforms the template in some cases. Compiling a resource using the
+        source's stringset will not produce the original source file if the
+        value of any `NSStringLocalizedFormatKey` key contains translatable
+        content.
+        """
+        pass
+
     def test_string(self):
         context_dict, openstring = self._create_pluralized_string()
         source = strip_leading_spaces(u"""


### PR DESCRIPTION
Make the Stringsdict format parser transform the source file in order to include all the translatable content in the produced strings.

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------
If my source looks like this:

```
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>TEST</key>
	<dict>
		<key>NSStringLocalizedFormatKey</key>
		<string>repeats %#@week_frequency@ on Monday</string>
		<key>week_frequency</key>
		<dict>
			<key>NSStringFormatSpecTypeKey</key>
			<string>NSStringPluralRuleType</string>
			<key>NSStringFormatValueTypeKey</key>
			<string>d</string>
			<key>one</key>
			<string>weekly</string>
			<key>other</key>
			<string>every %d weeks</string>
		</dict>
	</dict>
</dict>
</plist>
```

...then the following rules appear in the editor:
Form "one": weekly
Form "other": every %d weeks

This means that the "repeats [...] on Monday" part is never included and translated, but should be.

Steps to reproduce
------------------
Use a stringsdict file that contains translatable content in the top level of the plural rules, like this:

```
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>TEST</key>
	<dict>
		<key>NSStringLocalizedFormatKey</key>
		<string>repeats %#@week_frequency@ on Monday</string>
		<key>week_frequency</key>
		<dict>
			<key>NSStringFormatSpecTypeKey</key>
			<string>NSStringPluralRuleType</string>
			<key>NSStringFormatValueTypeKey</key>
			<string>d</string>
			<key>one</key>
			<string>weekly</string>
			<key>other</key>
			<string>every %d weeks</string>
		</dict>
	</dict>
</dict>
</plist>
```

Solution
--------

Transform the template, moving the translatable content *in* the plural rules, like this:
```      <key>NSStringLocalizedFormatKey</key>
		<string>%#@week_frequency@</string>
		<key>week_frequency</key>
		<dict>
			<key>NSStringFormatSpecTypeKey</key>
			<string>NSStringPluralRuleType</string>
			<key>NSStringFormatValueTypeKey</key>
			<string>d</string>
			<key>one</key>
			<string>repeats weekly on Monday</string>
			<key>other</key>
			<string>repeats every %d weeks on Monday</string>
		</dict>
```

Example run / Screenshots
-------------------------

Performance on live data
------------------------
