### PR TITLE
Update for django1.11

### DIFF
--- a/testbed/main/views.py
+++ b/testbed/main/views.py
@@ -76,7 +76,7 @@ class ApiView(HandlerMixin, View):
         elif payload['action'] == "compile":
             return_value = self._compile(payload)
         return HttpResponse(json.dumps(return_value),
-                            mimetype="application/json")
+                            content_type="application/json")
 
     def _choose_handler(self, payload):
         handler_name = payload['handler']

--- a/testbed/settings.py
+++ b/testbed/settings.py
@@ -2,7 +2,6 @@ import os
 
 
 OPENFORMATS_ROOT = os.path.dirname(__file__)
-
 # Django settings for testbed project.
 
 DEBUG = True
@@ -32,7 +31,7 @@ DATABASES = {
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -95,12 +94,14 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'b2e-1yz^*@(sggyqk=1bpf%al9sd8&8=@j#fxyb%5ewh!x$g9l'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(OPENFORMATS_ROOT, 'templates'),
+        ],
+    }
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -116,14 +117,6 @@ ROOT_URLCONF = 'testbed.urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'testbed.wsgi.application'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or
-    # "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    os.path.join(OPENFORMATS_ROOT, 'templates'),
-)
 
 INSTALLED_APPS = (
     'django.contrib.auth',


### PR DESCRIPTION
While the ```requirements.txt``` file states:
```django=1.11```

There are deprecated settings and function calls that don't allow django 1.11 to run smoothly.

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

Steps to reproduce
------------------

Solution
--------

Example run / Screenshots
-------------------------

Performance on live data
------------------------
