### PR TITLE
Fixed issue on Android compilation.

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -464,6 +464,8 @@ class AndroidHandler(Handler):
                 break
 
         if has_match:
+            # Make sure you include the <string-array> tag
+            self.transcriber.copy_until(item_itterator[0].start)
             # Compile found item nodes. Remove the rest.
             for item_tag in item_itterator:
                 self._compile_string(item_tag)

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -479,6 +479,45 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
         self._test_parse_error('<resources><string>hello</string></resources>',
                                u"Missing the `name` attribute on line 1")
 
+    def test_missing_first_item_in_array_list(self):
+        source = """
+            <resources>
+              <string-array name="settings_report_a_problem_problem_types">
+                  <item>@string/space</item>
+                  <item>Installation</item>
+                  <item>Bluetooth Connection</item>
+                  <item>Technical Troubleshooting</item>
+                  <item>How to use Navdy</item>
+                  <item>Ordering \u002F Shipping \u002F Payments</item>
+                  <item>Other</item>
+                  <item>Feedback \u0026 Suggestions</item>
+                  <item>Partnership Opportunities</item>
+                  <item>Send Logs</item>
+              </string-array>
+            </resources>
+        """
+        expected = """
+            <resources>
+              <string-array name="settings_report_a_problem_problem_types">
+                  <item>Installation</item>
+                  <item>Bluetooth Connection</item>
+                  <item>Technical Troubleshooting</item>
+                  <item>How to use Navdy</item>
+                  <item>Ordering \u002F Shipping \u002F Payments</item>
+                  <item>Other</item>
+                  <item>Feedback \u0026 Suggestions</item>
+                  <item>Partnership Opportunities</item>
+                  <item>Send Logs</item>
+              </string-array>
+            </resources>
+        """
+        template, stringset = self.handler.parse(source)
+        stringset.pop(0)
+        compiled = self.handler.compile(template, stringset)
+        self.assertEqual(
+            compiled, expected
+        )
+
     def test_compile_removes_missing_strings(self):
         source = strip_leading_spaces('''
             <resources>


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------
When compliling while missing the first item of a ```string-array``` tag it would result to an invalid XML."

Steps to reproduce
------------------
Parse a file with a ```string-array``` tag and before compiling remove the first element of the ```string-array```.

Example file:
```
<resources>
  <string-array name="settings_report_a_problem_problem_types">
      <item>@string/space</item>                              <!-- Keep this order !!! -->
      <item>Installation</item>                               <!-- Keep this order !!! -->
      <item>Bluetooth Connection</item>                       <!-- Keep this order !!! -->
      <item>Technical Troubleshooting</item>                  <!-- Keep this order !!! -->
      <item>How to use Navdy</item>                           <!-- Keep this order !!! -->
      <item>Ordering \u002F Shipping \u002F Payments</item>   <!-- Keep this order !!! -->
      <item>Other</item>                                      <!-- Keep this order !!! -->
      <item>Feedback \u0026 Suggestions</item>                <!-- Keep this order !!! -->
      <item>Partnership Opportunities</item>                  <!-- Keep this order !!! -->
      <item>Send Logs</item>                                  <!-- Keep this order !!! --><!-- Make sure to update spinnerClosed in ContactUsActivity if you change this -->
  </string-array>
</resources>
```

Solution
--------
When there are elements in the ```string-array``` ensure that you copy until the end of the ```string-array``` opening tag.

Example run / Screenshots
-------------------------

Performance on live data
------------------------
