### PR TITLE
Relax condition for pluralized yaml nodes

### DIFF
--- a/openformats/tests/formats/yamlinternationalization/files/1_el.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_el.yml
@@ -10,6 +10,19 @@ en:
     one: ""
     other: ""
 
+  pluralized_string_with_extra_keys:
+    one: el:One
+    other: el:Other
+
+  non_pluralized_string_with_extra_keys:
+    extra_key: "el:random value"
+    one: "el:One"
+    other: "el:Other"
+  plural_key_with_nested_nodes:
+    one:
+      nested_key: "el:One"
+    other: "el:Other"
+
   title: "el:About writing and formatting on GitHub"
   intro: "el:into text"
   numeric_var: 12.5

--- a/openformats/tests/formats/yamlinternationalization/files/1_en.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en.yml
@@ -9,6 +9,19 @@ en:
     one: ""
     other: ""
 
+  pluralized_string_with_extra_keys:
+    zero: Zero
+    one: One
+    other: Other
+  non_pluralized_string_with_extra_keys:
+    extra_key: random value
+    one: One
+    other: Other
+  plural_key_with_nested_nodes:
+    one:
+      nested_key: One
+    other: Other
+
   title: About writing and formatting on GitHub
   intro: into text
   numeric_var: 12.5

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
@@ -10,6 +10,19 @@ en:
     one: ""
     other: ""
 
+  pluralized_string_with_extra_keys:
+    one: One
+    other: Other
+
+  non_pluralized_string_with_extra_keys:
+    extra_key: random value
+    one: One
+    other: Other
+  plural_key_with_nested_nodes:
+    one:
+      nested_key: One
+    other: Other
+
   title: About writing and formatting on GitHub
   intro: into text
   numeric_var: 12.5

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
@@ -4,6 +4,17 @@ en:
     one: One ȧɠǿ
     other: Other ȧɠǿ
   another normal string: normal string
+  pluralized_string_with_extra_keys:
+    one: One
+    other: Other
+  non_pluralized_string_with_extra_keys:
+    extra_key: random value
+    one: One
+    other: Other
+  plural_key_with_nested_nodes:
+    one:
+      nested_key: One
+    other: Other
   title: About writing and formatting on GitHub
   intro: into text
   key1:

--- a/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
@@ -8,6 +8,17 @@ en:
     one: ""
     other: ""
 
+  pluralized_string_with_extra_keys:
+  dc063e48dfced0cb854d640b2bdca4f0_pl
+  non_pluralized_string_with_extra_keys:
+    extra_key: 3974770f06e9d24d79d07d48888bd85d_tr
+    one: 9977ff15b22f66a1493f3bed54e16d5b_tr
+    other: 8e71b7edd01d7d8b8d713799438dcb06_tr
+  plural_key_with_nested_nodes:
+    one:
+      nested_key: c82d2d83df32177a21068ba650454af9_tr
+    other: 910d07668f9dac883d140bb595532b09_tr
+
   title: 6391362253bdac99fff7bf50ff014be3_tr
   intro: e8c07422d0167fee3ecf8f3375ea5739_tr
   numeric_var: 12.5


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------
Right we expect a pluralized node to have exactly the plural rules the language supports and no extra key, otherwise we don't consider it pluralized. We need to relax this condition to allow extra keys to exist as long as all the plural rules are there.

Steps to reproduce
------------------
See updated test files for examples.

Solution
--------
* Consider a node pluralized even if there are extra keys in addition to the language plural rule keys as long as they are valid plural rules. Extra plural rules in this case are ignored completely, they don't appear in the editor and are not preserved in the translation file. If the extra keys are not plural rules the node is parsed as non-pluralized and each key will be a separate string.
* Make sure that when one or more of the plural rule keys contain a complex value, i.e. not a string, then this node is not going to be pluralized.

Example run / Screenshots
-------------------------

Performance on live data
------------------------
