### PR TITLE
Support custom tags in YAML format

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -67,6 +67,19 @@ class TxYamlLoader(yaml.SafeLoader):
             )
         return super(TxYamlLoader, self).compose_node(parent, index)
 
+    def _is_custom_tag(self, tag):
+        """
+        Check whether a value is tagged with a custom type.
+
+        Support custom tags, like: `foo: !bar test` Do not match `!!`, since it
+        indicates the built-in types. Match tags in the `!tag1!tag2!tag3` form.
+        """
+        # XXX: The  PyYAML library fails to handle multiple tags, like
+        # !tag1!tag2. There seems to be no workaround at the moment.
+        # XXX: We can't preserve the information whether the built-in `!!str`
+        # tag was used for a string
+        return re.match(r'^[\![a-zA-Z_]*]*$', tag, re.IGNORECASE)
+
     def construct_mapping(self, node, deep=True):
         """
         Override `yaml.SafeLoader.construct_mapping` to return for each item
@@ -94,13 +107,16 @@ class TxYamlLoader(yaml.SafeLoader):
                 hash(key)
             except TypeError as e:
                 print("Error while constructing a mapping, found unacceptable"
-                      " key (%s)".format(unicode(e)))
+                      " key ({})".format(unicode(e)))
                 continue
 
             if not(isinstance(value, unicode) or isinstance(value, str) or
                     isinstance(value, list) or isinstance(value, dict)):
                 continue
             start = value_node.start_mark.index
+            if self._is_custom_tag(value_node.tag):
+                # + 1 stands for the whitespace
+                start += len(value_node.tag) + 1
             end = value_node.end_mark.index
             style = ''
 

--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -4,6 +4,7 @@ import re
 import copy
 from StringIO import StringIO
 from yaml.emitter import Emitter
+from yaml.constructor import SafeConstructor
 
 from openformats.handlers import Handler
 from openformats.strings import OpenString
@@ -64,6 +65,8 @@ class YamlHandler(Handler):
         template = ""
         context = ""
         stringset = []
+        SafeConstructor.add_constructor(None,
+                                        SafeConstructor.construct_yaml_str)
         yaml_data = self._load_yaml(content, loader=TxYamlLoader)
         yaml_data = self._get_yaml_data_to_parse(yaml_data)
         parsed_data = self._parse_yaml_data(yaml_data, '', [], context)
@@ -86,8 +89,11 @@ class YamlHandler(Handler):
             )
             stringset.append(string_object)
             order += 1
-            template += (content[end:start] +
-                         string_object.template_replacement)
+            template = "{template}{prefix}{txhash}".format(
+                template=template,
+                prefix=content[end:start],
+                txhash=string_object.template_replacement,
+            )
             comment = self._find_comment(content, end, start)
             string_object.developer_comment = comment
             end = end_

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -69,3 +69,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - "el:another true value"
+
+# Custom tags
+foo:  !test "el:bar" # Should treat as string and ignore leading spaces
+bar: !xml "el:foo <xml>bar</xml>" # Also a string
+hello: "el:World" # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -72,3 +72,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - "another true value"
+
+# Custom tags
+foo:  !test bar # Should treat as string and ignore leading spaces
+bar: !xml "foo <xml>bar</xml>" # Also a string
+hello: !!str World # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -69,3 +69,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - "another true value"
+
+# Custom tags
+foo:  !test bar # Should treat as string and ignore leading spaces
+bar: !xml "foo <xml>bar</xml>" # Also a string
+hello: World # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -36,3 +36,6 @@ anchor_key:
   - value
 alias_key:
   - "another true value"
+foo: bar
+bar: "foo <xml>bar</xml>"
+hello: World

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -63,3 +63,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - ddc3cfcedcf1686d9e3ba6b99a0d091b_tr
+
+# Custom tags
+foo:  !test d06ae22aee8cc2abd5abd5a87cd784be_tr # Should treat as string and ignore leading spaces
+bar: !xml 14f55225e56b68a96e5df6b2377fa5f1_tr # Also a string
+hello: b0ed9cf22c0a5186d1c5b483a910dd33_tr # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore


### PR DESCRIPTION
Extend the YAML parser in order to include any translatable content that is marked with a custom type using tags.

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

YAML parser ignores any content behind [custom tags](http://camel.readthedocs.io/en/latest/yamlref.html#tags)

Steps to reproduce
------------------

Upload this YAML file:
```
foo: !bar Hello World
```

The translatable content `Hello World` will be ignored.

Solution
--------

The solution consists of two parts:
1. Handle any "untyped" content as string
2. If the node's type is a custom tag, shift the node's starting point in order to include it in the template

