### PR TITLE
Fix stringsdict bug with non-unicode characters

### DIFF
--- a/openformats/formats/stringsdict.py
+++ b/openformats/formats/stringsdict.py
@@ -186,10 +186,10 @@ class StringsDictHandler(Handler):
             text = self.transcriber.source[
                 self.transcriber.ptr:dict_tag.position
             ]
-            text = text.replace('<string>{}'.format(extras['prefix']),
-                                '<string>', 1)
-            text = text.replace('{}</string>'.format(extras['suffix']),
-                                '</string>', 1)
+            text = text.replace(u'<string>{}'.format(extras['prefix']),
+                                u'<string>', 1)
+            text = text.replace(u'{}</string>'.format(extras['suffix']),
+                                u'</string>', 1)
             self.transcriber.add(text)
             self.transcriber.skip_until(dict_tag.position)
         else:
@@ -220,7 +220,7 @@ class StringsDictHandler(Handler):
             # variable, we apply the prefix and the suffix to each of the
             # plural rules
             if extras is not None and extras["variable"] == secondary_key:
-                content = "{prefix}{content}{suffix}".format(
+                content = u"{prefix}{content}{suffix}".format(
                     prefix=extras["prefix"],
                     content=value_tag.content,
                     suffix=extras["suffix"],

--- a/openformats/tests/formats/stringsdict/files/1_el.stringsdict
+++ b/openformats/tests/formats/stringsdict/files/1_el.stringsdict
@@ -83,9 +83,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>el:One mouse</string>
+                <string>el:• One mouse •</string>
                 <key>other</key>
-                <string>el:%d mice</string>
+                <string>el:• %d mice •</string>
             </dict>
         </dict>
     </dict>

--- a/openformats/tests/formats/stringsdict/files/1_en.stringsdict
+++ b/openformats/tests/formats/stringsdict/files/1_en.stringsdict
@@ -75,7 +75,7 @@
         <key>LAST</key>
         <dict>
             <key>NSStringLocalizedFormatKey</key>
-            <string>%#@test@</string>
+            <string>%#@test@ •</string>
             <key>test</key>
             <dict>
                 <key>NSStringFormatSpecTypeKey</key>
@@ -83,9 +83,9 @@
                 <key>NSStringFormatValueTypeKey</key>
                 <string>d</string>
                 <key>one</key>
-                <string>One mouse</string>
+                <string>• One mouse</string>
                 <key>other</key>
-                <string>%d mice</string>
+                <string>• %d mice</string>
             </dict>
         </dict>
     </dict>


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [N/A] Performs well when applied to big organizations/resources/etc from our production database
* [N/A] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [N/A] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------

Non-ASCII characters in `stringsdict` files caused the parser to raise an exception.

Steps to reproduce
------------------

Use the [proposed test file](https://github.com/transifex/openformats/blob/7ede31f11c826d8927b267007b4fddfc87c85263/openformats/tests/formats/stringsdict/files/1_en.stringsdict) that contains the `•` character.

Solution
--------

Treat all strings as unicodes

Example run / Screenshots
-------------------------

Performance on live data
------------------------
