### PR TITLE
Improve YAML parser to avoid memory-eating behaviour

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -94,7 +94,7 @@ class TxYamlLoader(yaml.SafeLoader):
                 hash(key)
             except TypeError as e:
                 print("Error while constructing a mapping, found unacceptable"
-                      " key (%s)".format(unicode(e)))
+                      " key ({})".format(unicode(e)))
                 continue
 
             if not(isinstance(value, unicode) or isinstance(value, str) or

--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -232,30 +232,32 @@ class YamlHandler(Handler):
         if isinstance(yaml_data, dict):
             for key, node in yaml_data.items():
                 node_key = self._get_key_for_node(key, parent_key)
-                style = copy.copy(parent_style)
+                # Copy style for each node to avoid getting affected from the
+                # previous loops
+                node_style = copy.copy(parent_style)
                 if isinstance(node.value, dict):
                     if self.is_pluralized(node.value):
                         parsed_data.append(
                             self._parse_pluralized_leaf_node(
                                 node, node_key,
-                                style=copy.copy(parent_style or []),
+                                style=node_style,
                                 pluralized=True
                             )
                         )
                     else:
-                        style.append(node.style or '')
+                        node_style.append(node.style or '')
                         parsed_data = self._parse_yaml_data(
                             node.value, node_key, parsed_data, context,
-                            parent_style=copy.copy(style or []))
+                            parent_style=node_style)
                 elif isinstance(node.value, list):
-                    style.append(node.style or '')
+                    node_style.append(node.style or '')
                     parsed_data = self._parse_yaml_data(
                         node.value, node_key, parsed_data, context,
-                        parent_style=copy.copy(style or []))
+                        parent_style=node_style)
                 else:
                     parsed_data.append(
                         self._parse_leaf_node(
-                            node, node_key, style=copy.copy(parent_style or [])
+                            node, node_key, style=node_style
                         )
                     )
         elif (isinstance(yaml_data, list)):
@@ -264,15 +266,18 @@ class YamlHandler(Handler):
             # brackets around it. I.e.: 'foo.[0].bar'.
             for i, node in enumerate(yaml_data):
                 node_key = self._get_key_for_node('[%s]' % (i), parent_key)
+                # Copy style for each node to avoid getting affected from the
+                # previous loops
+                node_style = copy.copy(parent_style)
                 if isinstance(node.value, (dict, list)):
-                    parent_style.append(node.style or '')
+                    node_style.append(node.style or '')
                     parsed_data = self._parse_yaml_data(
                         node.value, node_key, parsed_data, context,
-                        parent_style=copy.copy(parent_style or []))
+                        parent_style=node_style)
                 else:
                     parsed_data.append(
                         self._parse_leaf_node(
-                            node, node_key, style=copy.copy(parent_style or [])
+                            node, node_key, style=node_style
                         )
                     )
 

--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -279,7 +279,7 @@ class YamlHandler(Handler):
                     )
 
     def _find_comment(self, content, start, end):
-        """ Finds comment lines that preceed a part of the YAML structure """
+        """ Finds comment lines that precede a part of the YAML structure """
         lines = [
             line.strip()
             for line in content[start:end].split('\n')


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [N/A] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [N/A] Errors are handled properly
* [N/A] All (conceivable) edge-cases are handled
* [N/A] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

YAML parser preserved the styles of the previous elements of a list, causing huge lists to crash since the parsing of an element required a huge array with unusable information.

Steps to reproduce
------------------

Upload a YAML file with a huge lists:
```
master_key:
  - key1: val
  - key2: val
...
  - key100000: val
```

Solution
--------

Avoid unused copies of the styles array. Rewrite the code that handles style inheritance.

Example run / Screenshots
-------------------------

Performance on live data
------------------------
