### PR TITLE
Preserve string styles in YAML i18n plural rules

### DIFF
--- a/openformats/tests/formats/yamlinternationalization/files/1_el.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_el.yml
@@ -10,6 +10,12 @@ en:
     one: ""
     other: ""
 
+  # A correct plural rule
+  pluralized_string_with_quotes:
+    one: 'el:this is a test'
+    other: "el:this is a double quote test"
+
+
   pluralized_string_with_extra_keys:
     one: el:One
     other: el:Other

--- a/openformats/tests/formats/yamlinternationalization/files/1_en.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en.yml
@@ -9,6 +9,11 @@ en:
     one: ""
     other: ""
 
+  # A correct plural rule
+  pluralized_string_with_quotes:
+    one: 'this is a test'
+    other: "this is a double quote test"
+
   pluralized_string_with_extra_keys:
     zero: Zero
     one: One

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
@@ -10,6 +10,12 @@ en:
     one: ""
     other: ""
 
+  # A correct plural rule
+  pluralized_string_with_quotes:
+    one: 'this is a test'
+    other: "this is a double quote test"
+
+
   pluralized_string_with_extra_keys:
     one: One
     other: Other

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
@@ -4,6 +4,9 @@ en:
     one: One ȧɠǿ
     other: Other ȧɠǿ
   another normal string: normal string
+  pluralized_string_with_quotes:
+    one: this is a test
+    other: this is a double quote test
   pluralized_string_with_extra_keys:
     one: One
     other: Other

--- a/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
@@ -8,6 +8,10 @@ en:
     one: ""
     other: ""
 
+  # A correct plural rule
+  pluralized_string_with_quotes:
+  e77d50fd048c3005883b3a99fd36fab3_pl
+
   pluralized_string_with_extra_keys:
   dc063e48dfced0cb854d640b2bdca4f0_pl
   non_pluralized_string_with_extra_keys:


### PR DESCRIPTION
Make the i18n YAML parser to preserve the style of each plural rule. This will preserve the quotations of the source language for each rule. If the translation contains a rule that is not present in the source
language, we use the style of the singular rule.

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

Plural rules were always printed without quotes in the translation files, even when the source file used quotes for them.

Steps to reproduce
------------------

Upload and translate the following i18n YAML file on Transifex:
```
en:
  test:
    one: "this has quotes"
    many: 'this is single quoted'
```
When you download the translated one (no matter the mode), the quotes are missing.

Solution
--------

Keep the styles of each plural rule as serialized dictionary. When compiling plural rules, we parse and use this dictionary to retrieve the style of each rule. 

Example run / Screenshots
-------------------------

Performance on live data
------------------------
