### PR TITLE
Fix YAML's plural rules width limit

### DIFF
--- a/openformats/formats/yaml/yaml_i18n.py
+++ b/openformats/formats/yaml/yaml_i18n.py
@@ -113,7 +113,6 @@ class I18nYamlHandler(YamlHandler):
             # version
             default_rule = self.get_rule_number('other')
             default_style = plural_styles_json.get(str(default_rule), '')
-            print(default_style)
             plural_style = plural_styles_json.get(str(rule), default_style)
             # Dump a Python dictionary that contains a single plural rule as a
             # single YAML rule and preserve the string's style
@@ -121,7 +120,8 @@ class I18nYamlHandler(YamlHandler):
                 {self.get_rule_string(rule): translation},
                 default_flow_style=False,
                 default_style=plural_style,
-                allow_unicode=True
+                allow_unicode=True,
+                width=float('inf'),
             ).decode('utf-8')
             # The safe_dump method places quotes around the keys too, which are
             # unnecessary. Remove them using the regular expression below.


### PR DESCRIPTION
Bu default, the PyYAML library applies a width limit when dumping strings, which auto-wraps the long strings. This caused a problem when dumping plurals without specifying a width causing the creation of invalid files. Specifying an "infinite" width will disable this auto-wrapping behavior.

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

Long text in plural rules gets wrapped and the i18n YAML parser produces invalid files.

Steps to reproduce
------------------

Upload the following i18n file:
```
en:
  test:
    one: test
    other: tests
```

and use this text as a translation `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`

Solution
--------

Specify an infinite width for the YAML dumper

Example run / Screenshots
-------------------------
N/A

Performance on live data
------------------------
N/A