### PR TITLE
Handle plurals with literal values

### DIFF
--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -420,8 +420,8 @@ class YamlHandler(Handler):
         Returns:
             The number of spaces.
         """
-        # match all whilespace characters after first `:` (end of first
-        # key). Stops on first non whitespace character.
+        # Match all whitespace characters after first `:` (end of first  key).
+        # Stops on first non whitespace character.
         indent_pattern = re.compile(':\r?\n(?P<indent>[ \t\n]+)')
         m = indent_pattern.search(template)
         indent = m.groups('indent')[0] if m else ' ' * 2


### PR DESCRIPTION
Correctly dump plural rules with literal or folded literal values. Apply the correct padding on each new line. This also fixes a bug that caused literal plurals to raise an unhandled exception.

Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [N/A] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [N/A] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [N/A] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------

The functionality that tried to replace the quotes from plural rule keys was raising an unhandled exception when the plural rule was literal or folded literal.

Steps to reproduce
------------------

Upload this file on Transifex as I18n YAML:
```
en:
  test:
      one: |
        literal
      other: >
        folded
```

Solution
--------

* Explicitly handle any exceptions raised from `re.sub` method
* Handle the cases were a plural has style different that single or double quotes. Create a fallback for those cases.
* Make sure literal and folded literal plural values are compiled correctly (eliminate the extra dash from PyYAML)

Example run / Screenshots
-------------------------

Performance on live data
------------------------
