### PR TITLE
Modify android escape functionality

### DIFF
--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -791,6 +791,26 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             # "a'b" => \"\a\"\b\"
             ([u'"', u'a', u"'", u'b', u'"'],
              [u'\\', u'"', u'a', u'\\', u"'", u'b', u'\\', u'"']),
+            # Simple
+            (u'<x y="z">hello</x>', u'<x y=\\"z\\">hello</x>'),
+            (u'<a b="c">"hello"</a>', u'<a b="c">\\"hello\\"</a>'),
+            # Combined
+            (u'<a b="c">hello</a><x y="z">hello</x>',
+             u'<a b="c">hello</a><x y=\\"z\\">hello</x>'),
+            # Nested
+            (u'<a b="c"><x y="z">hello</x></a>',
+             u'<a b="c"><x y=\\"z\\">hello</x></a>'),
+            (u'<x y="z"><a b="c">hello</a></x>',
+             u'<x y=\\"z\\"><a b="c">hello</a></x>'),
+            # Heads and tails
+            (u'this <x y="z">is escaped</x>, this <a b="c">isnt</a>, ok?',
+             u'this <x y=\\"z\\">is escaped</x>, this <a b="c">isnt</a>, ok?'),
+            # Not proper XML
+            (u'"0 < "1', u'\\"0 < \\"1'),
+            (u'<a>"b"</c>', u'<a>\\"b\\"</c>'),
+            # Single tags
+            (u'<a b="c" />', u'<a b="c" />'),
+            (u'<x y="z" />', u'<x y=\\"z\\" />'),
         )
         for rich, raw in cases:
             self.assertEquals(AndroidHandler.escape(bytes_to_string(rich)),


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [x] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------
Android xml generally should escape double quotes for strings, except when string contains:
- [localization placeholder `xliff:g`](https://developer.android.com/guide/topics/resources/localization#testing)
- link `a` .

Steps to reproduce
------------------
```
string = 'Lorem <a href="www.foo.com"> ipsum <xliff:g id="bar">fof bob</xliff:g>'
from openformats.formats.android import AndroidHandler
AndroidHandler.escape(string)
```

Solution
--------

Example run / Screenshots
-------------------------

Performance on live data
------------------------
