### PR TITLE
Fix xliff:g tag escaping in android xml

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -567,7 +567,7 @@ class AndroidHandler(Handler):
     # According to:
     # http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling  # noqa
 
-    INLINE_TAGS = ("xliff\:g", "a")
+    INLINE_TAGS = ("xliff:g", "a", "annotation")
 
     @staticmethod
     def escape(string):

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -811,6 +811,13 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             # Single tags
             (u'<a b="c" />', u'<a b="c" />'),
             (u'<x y="z" />', u'<x y=\\"z\\" />'),
+            # xliff:g tag
+            (u'<xliff:g y="z">hello</xliff:g>',
+             u'<xliff:g y="z">hello</xliff:g>'),
+            # annotation tag
+            (u'<annotation y="z">hello</annotation>',
+             u'<annotation y="z">hello</annotation>'),
+
         )
         for rich, raw in cases:
             self.assertEquals(AndroidHandler.escape(bytes_to_string(rich)),


### PR DESCRIPTION
Related with #109

Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------
Double quotes in properties of a xliff:g tag must not be escaped.
For example: `"Lorem" <xliff:g y="z"> ipsum </xliff:g>` => `\"Lorem\" <xliff:g y="z"> ipsum </xliff:g>`

Steps to reproduce
------------------

Solution
--------

Example run / Screenshots
-------------------------

Performance on live data
------------------------
