### PR TITLE
Support custom tags in YAML format

### DIFF
--- a/openformats/formats/yaml/constants.py
+++ b/openformats/formats/yaml/constants.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+YAML_STRING_ID = u'tag:yaml.org,2002:str'
+YAML_LIST_ID = u'tag:yaml.org,2002:seq'
+YAML_DICT_ID = u'tag:yaml.org,2002:map'
+YAML_BINARY_ID = u'tag:yaml.org,2002:binary'

--- a/openformats/formats/yaml/yaml_i18n.py
+++ b/openformats/formats/yaml/yaml_i18n.py
@@ -174,12 +174,12 @@ class I18nYamlHandler(YamlHandler):
                                     pluralized=False):
         """Parse a leaf node in yaml_dict.
         Args:
-            yaml_data: A tuple of the form (plurals_dict, start, end, style)
+            node: A tuple of the form (plurals_dict, start, end, style, tag)
                       that describes a pluralized node
                       `plurals_dict` example:
                           {
-                              "one": (string, start, end, style),
-                              "other": (string, start, end, style)
+                              "one": (string, start, end, style, tag),
+                              "other": (string, start, end, style, tag)
                           }
             parent_key: A string of keys concatenated by '.' to
                         reach this node
@@ -201,6 +201,7 @@ class I18nYamlHandler(YamlHandler):
             'end': end,
             'key': parent_key,
             'value': value,
+            'tag': None,
             'style': ':'.join(style or []),
             'pluralized': pluralized,
         }
@@ -218,8 +219,8 @@ class I18nYamlHandler(YamlHandler):
         Args:
             node: a dictionary of the form
               {
-                  "one": Node('string1', start, end, style),
-                  "other": Node('string2', start, end, style)
+                  "one": Node('string1', start, end, style, tag),
+                  "other": Node('string2', start, end, style, tag)
               }
         Returns:
             a dictionary of the form:

--- a/openformats/formats/yaml/yaml_representee_classes.py
+++ b/openformats/formats/yaml/yaml_representee_classes.py
@@ -7,20 +7,32 @@ in a dictionary for generating YAML content
 
 from collections import OrderedDict
 
+from openformats.formats.yaml.constants import YAML_STRING_ID
 
-class folded_unicode(unicode):  # noqa: N801
+
+class plain_unicode(unicode):  # noqa: N801
+
+    def __new__(self, value, tag=None):
+        self = super(plain_unicode, self).__new__(self, value)
+        self.tag = tag or YAML_STRING_ID
+        return self
+
     pass
 
 
-class literal_unicode(unicode):  # noqa: N801
+class folded_unicode(plain_unicode):  # noqa: N801
     pass
 
 
-class double_quoted_unicode(unicode):  # noqa: N801
+class literal_unicode(plain_unicode):  # noqa: N801
     pass
 
 
-class single_quoted_unicode(unicode):  # noqa: N801
+class double_quoted_unicode(plain_unicode):  # noqa: N801
+    pass
+
+
+class single_quoted_unicode(plain_unicode):  # noqa: N801
     pass
 
 

--- a/openformats/formats/yaml/yaml_representers.py
+++ b/openformats/formats/yaml/yaml_representers.py
@@ -6,40 +6,42 @@ YAML representers
 
 import yaml
 
+from openformats.formats.yaml.constants import (
+    YAML_STRING_ID,
+    YAML_LIST_ID,
+    YAML_DICT_ID,
+)
+
 
 def unicode_representer(dumper, data):
-    node = yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=data)
-    return node
+    tag = getattr(data, 'tag', YAML_STRING_ID)
+    return yaml.ScalarNode(tag=tag, value=data)
 
 
 def folded_unicode_representer(dumper, data):
-    return dumper.represent_scalar(
-        u'tag:yaml.org,2002:str', data, style='>')
+    return dumper.represent_scalar(YAML_STRING_ID, data, style='>')
 
 
 def literal_unicode_representer(dumper, data):
-    return dumper.represent_scalar(
-        u'tag:yaml.org,2002:str', data, style='|')
+    return dumper.represent_scalar(YAML_STRING_ID, data, style='|')
 
 
 def double_quoted_unicode_representer(dumper, data):
-    return dumper.represent_scalar(
-        u'tag:yaml.org,2002:str', data, style='"')
+    tag = getattr(data, 'tag', YAML_STRING_ID)
+    return dumper.represent_scalar(tag, data, style='"')
 
 
 def single_quoted_unicode_representer(dumper, data):
-    return dumper.represent_scalar(
-        u'tag:yaml.org,2002:str', data, style="'")
+    tag = getattr(data, 'tag', YAML_STRING_ID)
+    return dumper.represent_scalar(tag, data, style="'")
 
 
 def block_list_representer(dumper, data):
-    return dumper.represent_sequence(
-        'tag:yaml.org,2002:seq', data, flow_style=False)
+    return dumper.represent_sequence(YAML_LIST_ID, data, flow_style=False)
 
 
 def flow_list_representer(dumper, data):
-    return dumper.represent_sequence(
-        'tag:yaml.org,2002:seq', data, flow_style=True)
+    return dumper.represent_sequence(YAML_LIST_ID, data, flow_style=True)
 
 
 def ordered_dict_representer(dumper, data):
@@ -47,10 +49,10 @@ def ordered_dict_representer(dumper, data):
 
 
 def block_style_ordered_dict_representer(dumper, data):
-    return dumper.represent_mapping(
-        u'tag:yaml.org,2002:map', data.items(), flow_style=False)
+    return dumper.represent_mapping(YAML_DICT_ID, data.items(),
+                                    flow_style=False)
 
 
 def flow_style_ordered_dict_representer(dumper, data):
-    return dumper.represent_mapping(
-        u'tag:yaml.org,2002:map', data.items(), flow_style=True)
+    return dumper.represent_mapping(YAML_DICT_ID, data.items(),
+                                    flow_style=True)

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -69,3 +69,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - "el:another true value"
+
+# Custom tags
+foo:  !test "el:bar" # Should treat as string and ignore leading spaces
+bar: !xml "el:foo <xml>bar</xml>" # Also a string
+hello: "el:World" # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -72,3 +72,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - "another true value"
+
+# Custom tags
+foo:  !test bar # Should treat as string and ignore leading spaces
+bar: !xml "foo <xml>bar</xml>" # Also a string
+hello: !!str World # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -69,3 +69,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - "another true value"
+
+# Custom tags
+foo:  !test bar # Should treat as string and ignore leading spaces
+bar: !xml "foo <xml>bar</xml>" # Also a string
+hello: World # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -36,3 +36,6 @@ anchor_key:
   - value
 alias_key:
   - "another true value"
+foo: !test 'bar'
+bar: !xml "foo <xml>bar</xml>"
+hello: World

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -63,3 +63,10 @@ anchor_key: &an_anchor
 alias_key:
   - *an_anchor
   - ddc3cfcedcf1686d9e3ba6b99a0d091b_tr
+
+# Custom tags
+foo:  3e4000f6f4cd8bb27db6fb82e1b50bb4_tr # Should treat as string and ignore leading spaces
+bar: 75ce597a505a4faf6369b66b885926c8_tr # Also a string
+hello: b0ed9cf22c0a5186d1c5b483a910dd33_tr # Translatable
+number: !!int 123 # Should ignore
+bin: !!binary aGVsbG8= # Should ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django==1.11
 polib==1.0.3
 mistune==0.7.3
-PyYAML==3.10
+PyYAML==3.13
 pyparsing==2.2.0
 
 # InDesign


### PR DESCRIPTION
Extend the YAML parser in order to include any translatable content that is marked as a custom typed variable using tags. We store custom tags in OpenString's `context` field in order to preserve this information and include it when compiling YAML files.

Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [x] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------

YAML parser ignores any content behind [custom tags](http://camel.readthedocs.io/en/latest/yamlref.html#tags)

Steps to reproduce
------------------

Upload this YAML file:
```
foo: !bar Hello World
```

The translatable content `Hello World` will be ignored.

Solution
--------

Detect custom tags and save them to the `context` field of the `OpenString` object. When compiling files, check the `context` field and pre-pend the custom tags if it exists.