### PR TITLE
Fix YAML's string concatenation

### DIFF
--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -62,7 +62,7 @@ class YamlHandler(Handler):
                with the template_replacement in the template.
             4. Returns the (template, stringset) tuple.
         """
-        template = ""
+        template = []
         stringset = []
         # The first argument of the add_constructor method is the tag you want
         # to handle. If you provide None as an argument, all the unknown tags
@@ -96,13 +96,14 @@ class YamlHandler(Handler):
             )
             stringset.append(string_object)
             order += 1
-            template += (content[end:start] +
-                         string_object.template_replacement)
+            template.append("{}{}".format(content[end:start],
+                                          string_object.template_replacement))
             comment = self._find_comment(content, end, start)
             string_object.developer_comment = comment
             end = end_
 
-        template += content[end:]
+        template.append(content[end:])
+        template = ''.join(template)
         return template, stringset
 
     def compile(self, template, stringset, **kwargs):


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

YAML parser keeps concatenating strings using the `+=` operator which is inefficient.

Steps to reproduce
------------------

N/A

Solution
--------

Keep the string parts in a list and concatenate them once in the end using the `join` method.

Example run / Screenshots
-------------------------

N/A

Performance on live data
------------------------

N/A