### PR TITLE
Fix YAML's default tag value

### DIFF
--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -84,7 +84,7 @@ class YamlHandler(Handler):
             start = node.get('start')
             end_ = node.get('end')
             key = node.get('key')
-            tag = node.get('tag', '')
+            tag = node.get('tag')
             value = node.get('value')
             style = node.get('style')
             if not value:
@@ -92,7 +92,7 @@ class YamlHandler(Handler):
             if isinstance(value, dict) and not all(value.values()):
                 continue
             string_object = OpenString(
-                key, value, context=tag, flags=style, order=order,
+                key, value, context=tag or '', flags=style, order=order,
             )
             stringset.append(string_object)
             order += 1

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -130,6 +130,18 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
             self.handler.parse_pluralized_value('')
 
     def test_parse_invalid_yaml(self):
-        invalid_content = "foo: bar\nwrong intentation"
+        invalid_content = "foo: bar\nwrong indentation"
         with self.assertRaises(ParseError):
             self.handler.parse(invalid_content)
+
+    def test_openstring_attributes(self):
+        content = "foo: bar\ntest: !tag 'content'"
+        template, strings = self.handler.parse(content)
+
+        test_string = strings[0]
+        self.assertEqual(test_string.context, '')
+        self.assertEqual(test_string.flags, '')
+
+        content_string = strings[1]
+        self.assertEqual(content_string.context, '!tag')
+        self.assertEqual(content_string.flags, "'")

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
 
 setup(
     name="openformats",
-    version='0.0.40',
+    version='0.0.41',
     description="The Transifex Open Formats library",
     author="Transifex",
     author_email="support@transifex.com",


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [N/A] Performs well when applied to big organizations/resources/etc from our production database
* [N/A] Errors are handled properly
* [N/A] All (conceivable) edge-cases are handled
* [N/A] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------
The OpenString's context could be `None` if the tag was also `None`. We want the default context to be the empty string.

Steps to reproduce
------------------
N/A

Solution
--------
Perform an extra check and use the empty string as the default value

Example run / Screenshots
-------------------------
N/A

Performance on live data
------------------------
N/A