### PR TITLE
Escape leading at-signs in Android format

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -583,6 +583,11 @@ class AndroidHandler(Handler):
         """
 
         def _escape_text(string):
+            # If the string starts with an at-sign that doesn't identify
+            # another string, then we need to escape it using a leading
+            # backslash
+            if string.startswith(u'@') and not string.startswith(u'@string/'):
+                string = string.replace(u'@', u'\@', 1)
             return string.\
                 replace(DumbXml.DOUBLE_QUOTES,
                         u''.join([DumbXml.BACKSLASH, DumbXml.DOUBLE_QUOTES])).\
@@ -593,6 +598,10 @@ class AndroidHandler(Handler):
 
     @staticmethod
     def unescape(string):
+        # If the string starts with an escaped at-sign, do not display the
+        # backslash
+        if string.startswith(u'\@'):
+            string = string[1:]
         if len(string) and string[0] == string[-1] == DumbXml.DOUBLE_QUOTES:
             return string[1:-1].\
                 replace(u''.join([DumbXml.BACKSLASH, DumbXml.DOUBLE_QUOTES]),

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -817,7 +817,13 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             # annotation tag
             (u'<annotation y="z">hello</annotation>',
              u'<annotation y="z">hello</annotation>'),
-
+            # At-sign cases
+            (u'@', '\@'),
+            (u'@something', u'\@something'),
+            (u'"@enclosed"', u'\\"@enclosed\\"'),
+            (u'no need @', u'no need @'),
+            # Identifiers should remain intact
+            (u'@string/one', u'@string/one'),
         )
         for rich, raw in cases:
             self.assertEquals(AndroidHandler.escape(bytes_to_string(rich)),
@@ -856,6 +862,12 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             ([u'a', u"'", u'b', u'\\', u'c'], [u'a', u"'", u'b', u'\\', u'c']),
             # a\\"b => a\"b
             ([u'a', u'\\', u'\\', u'"', u'b'], [u'a', u'\\', u'"', u'b']),
+            # At-sign cases
+            (u'\@', '@'),
+            (u'\@something', u'@something'),
+            (u'\\"@enclosed\\"', u'"@enclosed"'),
+            (u'no need @', u'no need @'),
+            (u'@string/one', u'@string/one'),
         )
         for raw, rich in cases:
             self.assertEquals(AndroidHandler.unescape(bytes_to_string(raw)),

--- a/openformats/utils/xml.py
+++ b/openformats/utils/xml.py
@@ -33,6 +33,7 @@ def escape(string, inline_tags, escape_text):
     # Discard the temporary outer `<x>` tags
     return transcriber.get_destination()[3:-4]
 
+
 def _escape_tag(root, transcriber, inline_tags, escape_text):
     if root.text is None:
         # This is a single tag, eg <br />


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------

Leading at-signs in Android XML were not automatically escape/unescaped. For more information check [this reference](https://tekeye.uk/android/examples/android-string-resources-gotchas)

Steps to reproduce
------------------

Parse this file:
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <string name="score">\@score</string>
</resources>
```

Calling the unescape method on `\@score` should return `@score` which is the final text that will be displayed in the app.

Solution
--------

The escape method will replace `@` with `\@` when `@` is not used to refer another string.
The unescape method will do the opposite, replacing a leading `\@` with `@`.

Example run / Screenshots
-------------------------

Performance on live data
------------------------