### PR TITLE
Explicitly use UTF-8 encoding in YAML

### DIFF
--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -96,14 +96,14 @@ class YamlHandler(Handler):
             )
             stringset.append(string_object)
             order += 1
-            template.append("{}{}".format(content[end:start],
-                                          string_object.template_replacement))
+            template.append(u"{}{}".format(content[end:start],
+                                           string_object.template_replacement))
             comment = self._find_comment(content, end, start)
             string_object.developer_comment = comment
             end = end_
 
         template.append(content[end:])
-        template = ''.join(template)
+        template = u''.join(template)
         return template, stringset
 
     def compile(self, template, stringset, **kwargs):

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -76,3 +76,7 @@ bar: !xml "el:foo <xml>bar</xml>" # Also a string
 hello: "el:World" # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: "el:κείμενο"

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -79,3 +79,7 @@ bar: !xml "foo <xml>bar</xml>" # Also a string
 hello: !!str World # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -76,3 +76,7 @@ bar: !xml "foo <xml>bar</xml>" # Also a string
 hello: World # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -39,3 +39,4 @@ alias_key:
 foo: !test 'bar'
 bar: !xml "foo <xml>bar</xml>"
 hello: World
+σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -70,3 +70,7 @@ bar: 75ce597a505a4faf6369b66b885926c8_tr # Also a string
 hello: b0ed9cf22c0a5186d1c5b483a910dd33_tr # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: 8687f34a9bf89770b456b48ad2395788_tr


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [x] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------

Using non-ASCII characters in YAML keys would break the parser.

Steps to reproduce
------------------

Upload a YAML file with a key that contains a non-ASCII character.

Solution
--------

Explicitly use unicode strings everywhere. Add tests that contain comments and keys with non-ASCII characters in order to avoid such bugs in the future.

Example run / Screenshots
-------------------------

Performance on live data
------------------------
