### PR TITLE
openformats update (0.0.42)

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import re
 import itertools
-from hashlib import md5
 
 from ..handlers import Handler
 from ..strings import OpenString
@@ -58,13 +57,13 @@ class AndroidHandler(Handler):
         self.order_counter = itertools.count()
 
         source = self.transcriber.source
-        # Skip xml info declaration
+        # Skip XML info declaration
         resources_tag_position = source.index(self.PARSE_START)
 
         parsed = DumbXml(source, resources_tag_position)
         XMLUtils.validate_no_text_characters(self.transcriber, parsed)
         XMLUtils.validate_no_tail_characters(self.transcriber, parsed)
-        children_itterator = parsed.find_children(
+        children_iterator = parsed.find_children(
             self.STRING,
             self.STRING_ARRAY,
             self.STRING_PLURAL,
@@ -72,7 +71,7 @@ class AndroidHandler(Handler):
         )
         stringset = []
         self.existing_hashes = {}
-        for child in children_itterator:
+        for child in children_iterator:
             strings = self._handle_child(child)
             if strings is not None:
                 stringset.extend(strings)
@@ -150,9 +149,9 @@ class AndroidHandler(Handler):
         """
 
         string_rules_text = {}
-        item_itterator = child.find_children()
-        # Itterate through the children with the item tag.
-        for item_tag in item_itterator:
+        item_iterator = child.find_children()
+        # Iterate through the children with the item tag.
+        for item_tag in item_iterator:
             if item_tag.tag != DumbXml.COMMENT:
                 rule_number = self._validate_plural_item(item_tag)
                 string_rules_text[rule_number] = item_tag.content
@@ -191,10 +190,10 @@ class AndroidHandler(Handler):
                     else None.
         """
         strings = []
-        item_itterator = child.find_children(self.STRING_ITEM)
+        item_iterator = child.find_children(self.STRING_ITEM)
         name, product = self._get_child_attributes(child)
-        # Itterate through the children with the item tag.
-        for index, item_tag in enumerate(item_itterator):
+        # Iterate through the children with the item tag.
+        for index, item_tag in enumerate(item_iterator):
             XMLUtils.validate_no_tail_characters(self.transcriber, item_tag)
             child_name = u"{}[{}]".format(name, index)
             string = self._create_string(
@@ -381,7 +380,7 @@ class AndroidHandler(Handler):
         first_tag_position = parsed.text_position + len(parsed.text)
         self.transcriber.copy_until(first_tag_position)
 
-        children_itterator = parsed.find_children(
+        children_iterator = parsed.find_children(
             self.STRING,
             self.STRING_ARRAY,
             self.STRING_PLURAL
@@ -390,7 +389,7 @@ class AndroidHandler(Handler):
         self.is_source = is_source
         self.stringset = iter(stringset)
         self.next_string = self._get_next_string()
-        for child in children_itterator:
+        for child in children_iterator:
             self._compile_child(child)
 
         self.transcriber.copy_until(len(source))
@@ -450,28 +449,28 @@ class AndroidHandler(Handler):
         :NOTE: If the `string-array` was empty to begin with it will leave it
                 as it is.
         """
-        item_itterator = list(child.find_children(self.STRING_ITEM))
+        item_iterator = list(child.find_children(self.STRING_ITEM))
 
         # If placeholder (has no children) skip
-        if len(item_itterator) == 0:
+        if len(item_iterator) == 0:
             self.transcriber.copy_until(child.end)
             return
 
         # Check if any string matches array items
         has_match = False
-        for item_tag in item_itterator:
+        for item_tag in item_iterator:
             if self._should_compile(item_tag):
                 has_match = True
                 break
 
         if has_match:
             # Make sure you include the <string-array> tag
-            self.transcriber.copy_until(item_itterator[0].start)
+            self.transcriber.copy_until(item_iterator[0].start)
             # Compile found item nodes. Remove the rest.
-            for item_tag in item_itterator:
+            for item_tag in item_iterator:
                 self._compile_string(item_tag)
             self.transcriber.remove_section()
-            self.transcriber.add(item_itterator[-1].tail)
+            self.transcriber.add(item_iterator[-1].tail)
             self.transcriber.copy_until(child.end)
         else:
             # Remove the `string-array` tag
@@ -584,6 +583,11 @@ class AndroidHandler(Handler):
         """
 
         def _escape_text(string):
+            # If the string starts with an at-sign that doesn't identify
+            # another string, then we need to escape it using a leading
+            # backslash
+            if string.startswith(u'@') and not string.startswith(u'@string/'):
+                string = string.replace(u'@', u'\@', 1)
             return string.\
                 replace(DumbXml.DOUBLE_QUOTES,
                         u''.join([DumbXml.BACKSLASH, DumbXml.DOUBLE_QUOTES])).\
@@ -594,6 +598,10 @@ class AndroidHandler(Handler):
 
     @staticmethod
     def unescape(string):
+        # If the string starts with an escaped at-sign, do not display the
+        # backslash
+        if string.startswith(u'\@'):
+            string = string[1:]
         if len(string) and string[0] == string[-1] == DumbXml.DOUBLE_QUOTES:
             return string[1:-1].\
                 replace(u''.join([DumbXml.BACKSLASH, DumbXml.DOUBLE_QUOTES]),

--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -96,14 +96,14 @@ class YamlHandler(Handler):
             )
             stringset.append(string_object)
             order += 1
-            template.append("{}{}".format(content[end:start],
-                                          string_object.template_replacement))
+            template.append(u"{}{}".format(content[end:start],
+                                           string_object.template_replacement))
             comment = self._find_comment(content, end, start)
             string_object.developer_comment = comment
             end = end_
 
         template.append(content[end:])
-        template = ''.join(template)
+        template = u''.join(template)
         return template, stringset
 
     def compile(self, template, stringset, **kwargs):

--- a/openformats/tests/formats/android/test_android.py
+++ b/openformats/tests/formats/android/test_android.py
@@ -817,7 +817,13 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             # annotation tag
             (u'<annotation y="z">hello</annotation>',
              u'<annotation y="z">hello</annotation>'),
-
+            # At-sign cases
+            (u'@', '\@'),
+            (u'@something', u'\@something'),
+            (u'"@enclosed"', u'\\"@enclosed\\"'),
+            (u'no need @', u'no need @'),
+            # Identifiers should remain intact
+            (u'@string/one', u'@string/one'),
         )
         for rich, raw in cases:
             self.assertEquals(AndroidHandler.escape(bytes_to_string(rich)),
@@ -856,6 +862,12 @@ class AndroidTestCase(CommonFormatTestMixin, unittest.TestCase):
             ([u'a', u"'", u'b', u'\\', u'c'], [u'a', u"'", u'b', u'\\', u'c']),
             # a\\"b => a\"b
             ([u'a', u'\\', u'\\', u'"', u'b'], [u'a', u'\\', u'"', u'b']),
+            # At-sign cases
+            (u'\@', '@'),
+            (u'\@something', u'@something'),
+            (u'\\"@enclosed\\"', u'"@enclosed"'),
+            (u'no need @', u'no need @'),
+            (u'@string/one', u'@string/one'),
         )
         for raw, rich in cases:
             self.assertEquals(AndroidHandler.unescape(bytes_to_string(raw)),

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -76,3 +76,7 @@ bar: !xml "el:foo <xml>bar</xml>" # Also a string
 hello: "el:World" # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: "el:κείμενο"

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -79,3 +79,7 @@ bar: !xml "foo <xml>bar</xml>" # Also a string
 hello: !!str World # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -76,3 +76,7 @@ bar: !xml "foo <xml>bar</xml>" # Also a string
 hello: World # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -39,3 +39,4 @@ alias_key:
 foo: !test 'bar'
 bar: !xml "foo <xml>bar</xml>"
 hello: World
+σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -70,3 +70,7 @@ bar: 75ce597a505a4faf6369b66b885926c8_tr # Also a string
 hello: b0ed9cf22c0a5186d1c5b483a910dd33_tr # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Test with non-ASCII keys
+#σχόλιο
+σχόλιο: 8687f34a9bf89770b456b48ad2395788_tr

--- a/openformats/utils/xml.py
+++ b/openformats/utils/xml.py
@@ -33,6 +33,7 @@ def escape(string, inline_tags, escape_text):
     # Discard the temporary outer `<x>` tags
     return transcriber.get_destination()[3:-4]
 
+
 def _escape_tag(root, transcriber, inline_tags, escape_text):
     if root.text is None:
         # This is a single tag, eg <br />


### PR DESCRIPTION

Merged Pull Requests:

* transifex/openformats#122 - Explicitly use UTF-8 encoding in YAML
* transifex/openformats#120 - Escape leading at-signs in Android format
