### PR TITLE
Add html INLINE_TAGS for android xml escaping

### DIFF
--- a/openformats/formats/android.py
+++ b/openformats/formats/android.py
@@ -564,9 +564,11 @@ class AndroidHandler(Handler):
 
     # Escaping / Unescaping
     # According to:
-    # http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling  # noqa
-
-    INLINE_TAGS = ("xliff:g", "a", "annotation")
+    # https://developer.android.com/guide/topics/resources/string-resource#FormattingAndStyling
+    # https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML
+    INLINE_TAGS = ("xliff:g", "a", "annotation", "b", "em", "i", "cite", "dfn",
+                   "big", "small", "font", "tt", "s", "strike", "del", "u",
+                   "sup", "sub", "ul", "li", "br", "div", "span", "p")
 
     @staticmethod
     def escape(string):


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [x] Problem and solution are well-explained in the PR
* [x] Change is covered by unit-tests
* [x] Code is well documented
* [x] Code is styled well and is following best practices
* [x] Performs well when applied to big organizations/resources/etc from our production database
* [x] Errors are handled properly
* [x] All (conceivable) edge-cases are handled
* [x] Code is instrumented to report unexpected failures or increases in the failure rate
* [x] Commits have been squashed so that each one has a clear purpose (and green tests)
* [x] Proper labels have been applied

Problem
-------
Add html allowed inline tags to android format.
Check the android [documentation](https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML)

Steps to reproduce
------------------
```
$ docker-compose run --rm --entrypoint='python /app/manage.py shell' app
>>> from openformats.formats.android import AndroidHandler
>>> AndroidHandler("This is <font color='#FF0000' red")
>>> AndroidHandler.escape('This is <font color="#FF0000">red</font>')
u'This is <font color="#FF0000">red</font>'
```

Solution
--------

Example run / Screenshots
-------------------------

Performance on live data
------------------------
