### PR TITLE
Add helper for plural rules placeholders

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -300,7 +300,7 @@ class JsonHandler(Handler):
         replacement_pos = value.find(templ_replacement)
 
         if is_real_stringset:
-            replacement = ICUCompiler().serialize_string(string, delimiter=' ')
+            replacement = ICUCompiler().serialize_strings(string.string, delimiter=' ')
         else:
             replacement = templ_replacement
 

--- a/openformats/tests/util_tests/test_icu.py
+++ b/openformats/tests/util_tests/test_icu.py
@@ -4,10 +4,12 @@ import unittest
 
 from openformats.strings import OpenString
 from openformats.utils.icu import (ICUCompiler, ICUParser, ICUString,
-                                   normalize_plural_rule)
+                                   normalize_plural_rule, PLURAL_FORMAT_NUMERIC,
+                                   PLURAL_FORMAT_STRING)
 
 
 class ICUStringTestCase(unittest.TestCase):
+    """Test the ICUString class."""
 
     def test_strings_by_rule(self):
         """Make sure the strings_by_rule property works properly."""
@@ -23,6 +25,28 @@ class ICUStringTestCase(unittest.TestCase):
         self.assertDictEqual(
             icu_str.strings_by_rule,
             {0: u'0 lamparas', 1: u'1 lámpara', 5: u'{cnt} lamparas'},
+        )
+
+    def test_syntax_by_rule(self):
+        """Test the `syntax_by_rule` property."""
+        icu_str = ICUString(
+            'key',
+            [
+                ('=0', u'{0 pins}'),
+                ('=1', u'{one pin}'),
+                ('two', u'{a couple of pins}'),
+                ('other', u'{{cnt} pins}')
+            ],
+            pluralized=True,
+        )
+        self.assertDictEqual(
+            icu_str.syntax_by_rule,
+            {
+                0: PLURAL_FORMAT_NUMERIC,
+                1: PLURAL_FORMAT_NUMERIC,
+                2: PLURAL_FORMAT_STRING,
+                5: PLURAL_FORMAT_STRING,
+            },
         )
 
     def test_icustring_representation(self):
@@ -54,7 +78,7 @@ class ICUStringTestCase(unittest.TestCase):
 
 
 class ICUParserTestCase(unittest.TestCase):
-    """Test the functionality of the ICU module.
+    """Test the functionality of the ICUParser class.
 
     Most of its functionality is covered in the JSON tests, so here
     we only cover a few parts, namely:
@@ -96,13 +120,147 @@ class ICUParserTestCase(unittest.TestCase):
         self.assertEqual(normalize_plural_rule('anything'), 'anything')
 
 
-class ICUCompilerTestCase(unittest.TestCase):
-    """Test the functionality of the ICU module."""
-    def test_compiler(self):
-        """Make sure that ICUCompiler works as expected."""
+class ICUCompilerSerializationTestCase(unittest.TestCase):
+    """Test the serialization functionality of the ICUCompiler class."""
+
+    def test_compile_with_default_delimiter(self):
+        """Make sure that serialization with a default delimiter
+        works as expected."""
         openstring = OpenString('key', {1: u'χαλί', 5: u'χαλιά'}, pluralized=True)
-        string = ICUCompiler().serialize_string(openstring)
+        string = ICUCompiler().serialize_strings(openstring.string)
         self.assertEqual(
             u'one {χαλί} other {χαλιά}',
             string,
+        )
+
+    def test_compile_with_custom_delimiter(self):
+        """Make sure that serialization with a custom delimiter
+        works as expected."""
+        openstring = OpenString('key', {1: u'χαλί', 5: u'χαλιά'}, pluralized=True)
+        string = ICUCompiler().serialize_strings(openstring.string, '\n')
+        self.assertEqual(
+            u'one {χαλί}\nother {χαλιά}',
+            string,
+        )
+
+    def test_compile_with_custom_syntax_per_rule(self):
+        """Make sure that serialization with a custom syntax
+        works as expected."""
+        openstring = OpenString(
+            'key', {1: u'χαλί', 2: u'δύο χαλιά', 3: u'λίγα χαλιά', 5: u'χαλιά'},
+            pluralized=True,
+        )
+        string = ICUCompiler().serialize_strings(
+            openstring.string,
+            syntax_by_rule={
+                1: PLURAL_FORMAT_NUMERIC,
+                2: PLURAL_FORMAT_NUMERIC,
+                3: PLURAL_FORMAT_STRING,
+                # omit the last one on purpose, should be rendered as string
+            },
+        )
+        self.assertEqual(
+            u'=1 {χαλί} =2 {δύο χαλιά} few {λίγα χαλιά} other {χαλιά}',
+            string,
+        )
+
+
+class ICUCompilerPlaceholderCreationTestCase(unittest.TestCase):
+    """Test the creation of placeholder hashes in the ICUCompiler
+    class.
+
+    Tests the _create_placeholders_by_rule() method.
+    """
+
+    def test_with_more_target_languages(self):
+        icu_string = ICUParser().parse(
+            'doesntmatter',
+            u'{count, plural, one {ac76ac7a27_pl_0} other {ac76ac7a27_pl_1}}'
+        )
+        placeholders = ICUCompiler._create_placeholders_by_rule(
+            icu_string,
+            [1, 2, 3, 4, 5]
+        )
+        self.assertDictEqual(
+            {
+                1: u'ac76ac7a27_pl_0',
+                2: u'ac76ac7a27_pl_1',
+                3: u'ac76ac7a27_pl_2',
+                4: u'ac76ac7a27_pl_3',
+                5: u'ac76ac7a27_pl_4',
+            },
+            placeholders,
+        )
+
+    def test_with_less_target_languages(self):
+        icu_string = ICUParser().parse(
+            'doesntmatter',
+            u'{count, plural, one {ac76ac7a27_pl_0} other {ac76ac7a27_pl_1}}'
+        )
+        placeholders = ICUCompiler._create_placeholders_by_rule(
+            icu_string,
+            [5]
+        )
+        self.assertDictEqual(
+            {
+                5: u'ac76ac7a27_pl_0',
+            },
+            placeholders,
+        )
+
+
+class ICUCompilerSerializePlaceholdersTestCase(unittest.TestCase):
+    """Test the serialization of placeholder hashes in the ICUCompiler
+    class.
+
+    Tests the serialize_placeholder_string() method.
+    """
+
+    def test_with_more_target_plurals(self):
+        icu_string = ICUParser().parse(
+            'doesntmatter',
+            u'{count, plural, one {ac76ac7a27_pl_0} other {ac76ac7a27_pl_1}}'
+        )
+        serialized = ICUCompiler().serialize_placeholder_string(
+            icu_string,
+            [1, 2, 3, 4, 5]
+        )
+        self.assertEqual(
+            u'one {s}_0} two {s}_1} few {s}_2} many {s}_3} other {s}_4}'.replace(
+                u'{s}', u'{ac76ac7a27_pl',
+            ),
+            serialized,
+        )
+
+    def test_with_less_target_plurals(self):
+        icu_string = ICUParser().parse(
+            'doesntmatter',
+            u'{count, plural, one {ac76ac7a27_pl_0} few {ac76ac7a27_pl_1} '
+            u'other {ac76ac7a27_pl_2}}'
+        )
+        serialized = ICUCompiler().serialize_placeholder_string(
+            icu_string,
+            [1, 5]
+        )
+        self.assertEqual(
+            u'one {s}_0} other {s}_1}'.replace(
+                u'{s}', u'{ac76ac7a27_pl',
+            ),
+            serialized,
+        )
+
+    def test_with_different_target_plurals(self):
+        icu_string = ICUParser().parse(
+            'doesntmatter',
+            u'{count, plural, one {ac76ac7a27_pl_0} other {ac76ac7a27_pl_2}}'
+        )
+        serialized = ICUCompiler().serialize_placeholder_string(
+            icu_string,
+            [2, 5]
+        )
+        self.assertEqual(
+            u'two {s}_0} other {s}_1}'.replace(
+                u'{s}', u'{ac76ac7a27_pl',
+            ),
+            serialized,
         )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
 
 setup(
     name="openformats",
-    version='0.0.45',
+    version='0.0.46',
     description="The Transifex Open Formats library",
     author="Transifex",
     author_email="support@transifex.com",


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem and/or solution
-------
Add a helper function that replaces all serialized plural rule placeholders (hashes), that correspond to the source language, with those that correspond to the given target language rules.

This is useful when the template does not serialize all pluralized content for a string (e.g. "{count, plural, <hash>}"), but rather adds one hash placeholder for each rule (e.g. "{count, plural, one {<hash1>} other {<hash2>}").

In the latter case, when compiling, the existing source placeholders need to be removed completely, and the target placeholders need to appear in their place.
