### PR TITLE
Create a customizable XML format

### DIFF
--- a/openformats/formats/customizable_xml.py
+++ b/openformats/formats/customizable_xml.py
@@ -1,0 +1,282 @@
+from __future__ import absolute_import
+
+import itertools
+
+from ..handlers import Handler
+from ..strings import OpenString
+from ..transcribers import Transcriber
+from ..utils.xml import NewDumbXml
+from ..utils.xmlutils import reraise_syntax_as_parse_errors
+
+
+# These are the default values of the tags and attributes
+# that will be used for parsing and compiling, if no custom
+# values are provided
+DEFAULT_ROOT_NAME = 'strings'
+DEFAULT_SECTION_NAME = 'section'
+DEFAULT_SECTION_ID_NAME = 'name'
+DEFAULT_STRING_NAME = 'string'
+DEFAULT_STRING_KEY_NAME = 'key'
+DEFAULT_BASE_STRING_NAME = 'base'
+DEFAULT_VARIANT_STRING_NAME = 'variant'
+DEFAULT_VARIANT_STRING_CONTEXT_NAME = 'context'
+
+# NOTE: Additional customization that can be implemented in the future:
+# - keys include the section name as well
+# - translatable text can be either in a tag like <base> or
+#   as the text of the <string> tag
+# - sections support nesting
+
+# When a string key is composed of various parts,
+# they are joined together using this delimiter, e.g.
+# <string key="some_key>
+#   <base>...</base>
+#   <variant context="some_context">...</variant>
+# </string>
+# -> the string key of the variant string will be: "some_key::some_context"
+COMPOSITE_KEY_SEPARATOR = '::'
+
+
+class CustomizableXMLHandler(Handler):
+    """A file format that supports XML files whose structure
+    is customizable to a certain degree.
+
+    The structure looks like this:
+    <strings>
+      <section name="group1">
+        <string key="key1">
+          <base>A translatable string</base>
+        </string>
+        <string key="pressed_button">
+          <base>The user pressed the button</base>
+          <variant context="male">He pressed the button</variant>
+          <variant context="female">She pressed the button</variant>
+        </string>
+      </section>
+
+      <section name="group2">
+        <string key="key2">
+          <base>Another translatable string</base>
+        </string>
+      </section>
+    </strings>
+
+    The structure must be followed as shown above, but the names of
+    all tags and attributes can be customized. For example, the following
+    is also supported:
+    <root>
+      <group name="group1">
+        <str id="key1">
+          <base>A translatable string</base>
+        </str>
+        <str id="pressed_button">
+          <base>The user pressed the button</base>
+          <alt context="male">He pressed the button</alt>
+          <alt context="female">She pressed the button</alt>
+        </str>
+      </group>
+    </root>
+    """
+
+    name = "CUSTOM_XML"
+    extension = "xml"
+    EXTRACTS_RAW = False
+
+    def __init__(self, **kwargs):
+        super(CustomizableXMLHandler, self).__init__()
+        # Setup the customization
+        # Use the provided values or fallback to the defaults
+        self.root_name = kwargs.get('root_name', DEFAULT_ROOT_NAME)
+        self.section_name = kwargs.get('section_name', DEFAULT_SECTION_NAME)
+        self.section_id_name = kwargs.get(
+            'section_id_name', DEFAULT_SECTION_ID_NAME
+        )
+        self.string_name = kwargs.get('string_name', DEFAULT_STRING_NAME)
+        self.string_key_name = kwargs.get(
+            'string_key_name', DEFAULT_STRING_KEY_NAME
+        )
+        self.base_string_name = kwargs.get(
+            'base_string_name', DEFAULT_BASE_STRING_NAME
+        )
+        self.variant_string_name = kwargs.get(
+            'variant_string_name', DEFAULT_VARIANT_STRING_NAME
+        )
+        self.variant_string_context_name = kwargs.get(
+            'variant_string_id_name', DEFAULT_VARIANT_STRING_CONTEXT_NAME
+        )
+
+        # Define some variables
+        self.transcriber = None
+        self.stringset = None
+        self.next_string = None
+
+    @reraise_syntax_as_parse_errors
+    def parse(self, content, **kwargs):
+        """Parse the given string content and return a template and
+        a stringset of the parsed content.
+
+        The template will contain placeholders in the place of all
+        translatable strings.
+
+        :param str content: the complete string to parse
+        :return: the template and the parsed stringset
+        :rtype: tuple(str, list(OpenString))
+        """
+        order_counter = itertools.count()
+        transcriber = Transcriber(content)
+        source = transcriber.source
+
+        # Everything starts at the root tag
+        root_tag_pos = source.index('<{}'.format(self.root_name))
+        parsed = NewDumbXml(source, root_tag_pos)
+        stringset = []
+
+        # Translatable content is organized under <section> tags
+        for section_tag in parsed.find_children(self.section_name):
+
+            # Find all <string> children tags
+            for string_tag in section_tag.find_children(self.string_name):
+                base_strings = list(string_tag.find_children(self.base_string_name))
+                variants = list(string_tag.find_children(self.variant_string_name))
+                all_tags = sorted(
+                    variants + base_strings,
+                    key=lambda t: t.position
+                )
+
+                for tag in all_tags:
+                    # No translatable content found, move on
+                    if not tag.content:
+                        continue
+
+                    key = self._get_key(string_tag, tag)
+                    string = OpenString(
+                        key,
+                        tag.content,
+                        context=section_tag.attrib[self.section_id_name],
+                        order=order_counter.next(),
+                    )
+                    stringset.append(string)
+
+                    # Move the transcriber accordingly, so that
+                    # the content includes the hash placeholder
+                    transcriber.copy_until(tag.text_position)
+                    transcriber.add(string.template_replacement)
+                    transcriber.skip(len(tag.content))
+
+        # All translatable content has been handled,
+        # now copy the rest of the content as is
+        transcriber.copy_until(len(source))
+
+        template = transcriber.get_destination()
+        return template, stringset
+
+    def compile(self, template, stringset, is_source=True, language_info=None):
+        """Compile the given `template` by replacing all hash placeholders
+        with the translations found in `stringset`.
+
+        :param str template: the template that contains hash placeholders
+            in the place of translatable text
+        :param list stringset: a list of OpenString objects that represent
+            all translations that should go into the template
+        :param bool is_source: True if compiling for the source language,
+            False otherwise
+        :param dict language_info: a dictionary structured as:
+            {'name': <language_name>, 'code': <language_code>}
+        :return: the compiled string, which contains all translations
+        :rtype: str
+        """
+        root_tag_pos = template.index('<{}'.format(self.root_name))
+
+        self.transcriber = Transcriber(template[root_tag_pos:])
+        source = self.transcriber.source
+
+        parsed = NewDumbXml(source)
+        string_iterator = parsed.find_descendants(self.string_name)
+
+        self.stringset = iter(stringset)
+        self.next_string = self._get_next_string()
+
+        for string_tag in string_iterator:
+            self._compile_string(string_tag)
+
+        self.transcriber.copy_to_end()
+        compiled = (
+            template[:root_tag_pos] + self.transcriber.get_destination()
+        )
+
+        return compiled
+
+    def _compile_string(self, string_tag):
+        """Use the given `string_tag` in order to update the template,
+        replacing all hash placeholders with the translated content.
+
+        Updates the transcriber directly.
+
+        :param NewNewDumbXml string_tag: an XML tag that may contain children
+            with translatable content, e.g.
+            <string key="..." attr2="..." attr3="...">
+              <base>A string<base>
+              <variant context="a">Another string</variant>
+              <variant context="b">Yet another string</variant>
+            </string>
+        """
+        # Copy until "<string key="..." ...>"
+        self.transcriber.copy_until(string_tag.text_position)
+
+        base_and_variants = string_tag.find_children(
+            self.base_string_name, self.variant_string_name,
+        )
+        for translatable_str_node in base_and_variants:
+            # Copy until "<base>" or "<variant>"
+            self.transcriber.copy_until(translatable_str_node.text_position)
+
+            # Only consume the current translation if the XML node has text
+            if translatable_str_node.text:
+                # Add the translation
+                self.transcriber.add(self.next_string.string)
+                self.next_string = self._get_next_string()
+
+            # Skip the hash placeholder
+            self.transcriber.skip_until(translatable_str_node.content_end)
+            # Copy until "</base>" or "</variant>"
+            self.transcriber.copy_until(translatable_str_node.tail_position)
+
+    def _get_key(self, string_tag, tag):
+        """Return the key that corresponds to a given translatable string.
+
+        Uses the attributes of the outer `string_tag` and the inner `tag`
+        in order to construct a key.
+
+        :param NewDumbXml string_tag: the outer XML tag that
+            may contain various translatable strings
+        :param NewDumbXml tag: the inner XML tag that contains
+            one translatable string
+        :return: the key of the corresponding translatable string
+        :rtype: str
+        """
+        # Base string
+        if tag.tag == self.base_string_name:
+            return string_tag.attrib[self.string_key_name]
+
+        # Variant
+        else:
+            return "{key}{separator}{variant_id}".format(
+                key=string_tag.attrib[self.string_key_name],
+                separator=COMPOSITE_KEY_SEPARATOR,
+                variant_id=tag.attrib[self.variant_string_context_name],
+            )
+
+    def _get_next_string(self):
+        """Get the next string from an iterable stringset.
+
+        Return None if there is no other string.
+
+        :return: An OpenString object or None if it has reached the end of
+            the iterable
+        """
+        try:
+            next_string = self.stringset.next()
+        except StopIteration:
+            next_string = None
+        return next_string
+

--- a/openformats/tests/formats/customizable_xml/files/1_el.xml
+++ b/openformats/tests/formats/customizable_xml/files/1_el.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<strings>
+    <section name="group1" tag1="something" tag2="something">
+        <string key="key1" tag1="t1" tag2="t2">
+            <base tag="tt">el:A translatable string</base>
+        </string>
+        <string key="pressed_button">
+            <base>el:The user pressed the button</base>
+            <variant tag-pre="pre" context="male" tag-post="post">el:He pressed the button</variant>
+            <variant context="female">el:She pressed the button</variant>
+        </string>
+    </section>
+    <section name="group2">
+        <string key="key2">
+            <base>el:Another translatable string</base>
+        </string>
+        <string key="key3">
+            <base></base>
+            <variant context="a"></variant>
+            <variant></variant>
+        </string>
+        <string key="key4">
+            <base>el:Some entity</base>
+        </string>
+    </section>
+    <section name="empty_group">
+        <random my-tag="yo">Anything</random>
+    </section>
+</strings>

--- a/openformats/tests/formats/customizable_xml/files/1_en.xml
+++ b/openformats/tests/formats/customizable_xml/files/1_en.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<strings>
+    <section name="group1" tag1="something" tag2="something">
+        <string key="key1" tag1="t1" tag2="t2">
+            <base tag="tt">A translatable string</base>
+        </string>
+        <string key="pressed_button">
+            <base>The user pressed the button</base>
+            <variant tag-pre="pre" context="male" tag-post="post">He pressed the button</variant>
+            <variant context="female">She pressed the button</variant>
+        </string>
+    </section>
+    <section name="group2">
+        <string key="key2">
+            <base>Another translatable string</base>
+        </string>
+        <string key="key3">
+            <base></base>
+            <variant context="a"></variant>
+            <variant></variant>
+        </string>
+        <string key="key4">
+            <base>Some entity</base>
+        </string>
+    </section>
+    <section name="empty_group">
+        <random my-tag="yo">Anything</random>
+    </section>
+</strings>

--- a/openformats/tests/formats/customizable_xml/files/1_tpl.xml
+++ b/openformats/tests/formats/customizable_xml/files/1_tpl.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<strings>
+    <section name="group1" tag1="something" tag2="something">
+        <string key="key1" tag1="t1" tag2="t2">
+            <base tag="tt">b8535dff24f1c17468c87beef1f53ef7_tr</base>
+        </string>
+        <string key="pressed_button">
+            <base>5d93729f62679a39c7222b559dba2402_tr</base>
+            <variant tag-pre="pre" context="male" tag-post="post">25e6726d12b93463930ab96b28d10ec8_tr</variant>
+            <variant context="female">d211229b5f0c91dcecc411b35ccd0e5b_tr</variant>
+        </string>
+    </section>
+    <section name="group2">
+        <string key="key2">
+            <base>f4cf827ab746b78845a8b4613ce23c70_tr</base>
+        </string>
+        <string key="key3">
+            <base></base>
+            <variant context="a"></variant>
+            <variant></variant>
+        </string>
+        <string key="key4">
+            <base>a620c67be79a511bfb55b18945d6167e_tr</base>
+        </string>
+    </section>
+    <section name="empty_group">
+        <random my-tag="yo">Anything</random>
+    </section>
+</strings>

--- a/openformats/tests/formats/customizable_xml/test_customizable_xml.py
+++ b/openformats/tests/formats/customizable_xml/test_customizable_xml.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from openformats.formats.customizable_xml import CustomizableXMLHandler
+
+from openformats.exceptions import ParseError
+from openformats.strings import OpenString
+
+from openformats.tests.formats.common import CommonFormatTestMixin
+
+
+TEST_CONTENT = u"""
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <group name="group1">
+    <str id="key1">
+      <s>{s[0]}</s>
+    </str>
+    <str id="pressed_button">
+      <s>{s[1]}</s>
+      <alt info="male">{s[2]}</alt>
+      <alt info="female">{s[3]}</alt>
+    </str>
+  </group>
+
+  <group name="group2">
+    <str id="key2">
+      <s>{s[4]}</s>
+    </str>
+  </group>
+</root>
+"""
+
+SOURCE_TRANSLATIONS = [
+    u'A translatable string',
+    u'The user pressed the button',
+    u'He pressed the button',
+    u'She pressed the button',
+    u'Another translatable string',
+]
+GREEK_TRANSLATIONS = [
+    u'Ένα κείμενο για μετάφραση',
+    u'Ο χρήστης πάτησε το κουμπί',
+    u'Αυτός πάτησε το κουμπί',
+    u'Αυτή πάτησε το κουμπί',
+    u'Ένα ακόμα κείμενο για μετάφραση',
+]
+
+
+class CustomizableXMLTestCase(CommonFormatTestMixin, unittest.TestCase):
+    """Tests the functionality of the CustomizableXML handler."""
+
+    HANDLER_CLASS = CustomizableXMLHandler
+    TESTFILE_BASE = "openformats/tests/formats/customizable_xml/files"
+
+    def test_customized_names(self):
+        """Test custom options in XML structure, using default
+        translations."""
+        content = _get_test_content()
+        handler = _get_custom_handler()
+        template, stringset = handler.parse(content)
+
+        compiled = handler.compile(template, _create_stringset())
+        self.assertEqual(content, compiled)
+
+    def test_customized_names_with_new_translations(self):
+        """Test custom options in XML structure, using custom
+        translations."""
+        content = _get_test_content()
+        handler = _get_custom_handler()
+        template, stringset = handler.parse(content)
+
+        new_translations = GREEK_TRANSLATIONS
+        compiled = handler.compile(
+            template, _create_stringset(new_translations),
+        )
+        self.assertEqual(_get_test_content(new_translations), compiled)
+
+    def test_missing_root_node_on_parsing_raises_error(self):
+        content = _get_test_content()
+        handler = CustomizableXMLHandler(
+            root_name='invalid',  # anything other than 'root'
+        )
+        with self.assertRaises(ParseError) as context:
+            handler.parse(content)
+        self.assertEqual(
+            str(context.exception),
+            'Root node "<invalid>" not found',
+        )
+
+    def test_missing_key_in_string_node_on_parsing_raises_error(self):
+        content = _get_test_content()
+        handler = _get_custom_handler()
+        handler.string_key_name = 'mykey'  # anything other than 'key'
+
+        with self.assertRaises(ParseError) as context:
+            handler.parse(content)
+        self.assertEqual(
+            str(context.exception),
+            'Missing "{key}" attribute in <{string}> node, '
+            'parent of "<{tag}>A translatable string</{tag}>"'.format(
+                key=handler.string_key_name,
+                string=handler.string_name,
+                tag='s',
+            )
+        )
+
+    def test_missing_root_node_on_compiling_raises_error(self):
+        content = _get_test_content()
+        handler = _get_custom_handler()
+        template, stringset = handler.parse(content)
+
+        handler.root_name = 'invalid'  # anything other than 'root'
+        with self.assertRaises(ParseError) as context:
+            handler.compile(template, _create_stringset())
+        self.assertEqual(
+            str(context.exception),
+            'Root node "<invalid>" not found',
+        )
+
+
+def _create_stringset(translations=None):
+    """Get a list of OpenString objects to use in compilation.
+
+    :param list translations: the list of str objects to use as translations,
+        or the default source translations, if omitted
+    :return: a list of OpenString objects
+    :rtype: list
+    """
+    translations = translations or SOURCE_TRANSLATIONS
+    return [
+        OpenString('key', string, order=index)
+        for index, string in enumerate(translations)
+    ]
+
+
+def _get_test_content(translations=None):
+    """Get a content as an XML string, containing the given translations.
+
+    If no translations are provided, the default source translations
+    are used.
+
+    :param list translations: a list of str objects to use,
+        or the default source translations if omitted
+    :return: the XML string
+    :rtype: str
+    """
+    translations = translations or SOURCE_TRANSLATIONS
+    return TEST_CONTENT.format(s=translations)
+
+
+def _get_custom_handler():
+    """Get a new handler that uses specific custom options
+    that are compatible with the structure of TEST_CONTENT.
+
+    :return: a new handler instance
+    :rtype: CustomizableXMLHandler
+    """
+    return CustomizableXMLHandler(
+        root_name='root',
+        section_name='group',
+        section_id_name='name',
+        string_name='str',
+        string_key_name='id',
+        base_string_name='s',
+        variant_string_name='alt',
+        variant_string_id_name='info',
+    )

--- a/openformats/transcribers.py
+++ b/openformats/transcribers.py
@@ -99,6 +99,9 @@ class Transcriber(object):
 
         self.newline_count += chunk.count('\n')
 
+    def copy_to_end(self):
+        self.copy_until(len(self.source))
+
     def add(self, text):
         self.destination.append(text)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
 
 setup(
     name="openformats",
-    version='0.0.46',
+    version='0.0.47',
     description="The Transifex Open Formats library",
     author="Transifex",
     author_email="support@transifex.com",


### PR DESCRIPTION
Problem
-------
We need a file format that handles XML, with a certain degree of customization regarding its structure.

Solution
--------
Created a format that follows a certain structure, but allows the customization of the names of the tags and attributes it uses.

Checklist (for the reviewer)
----------------------------
* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied