### PR TITLE
Implement structured JSON format

### DIFF
--- a/openformats/tests/formats/structuredkeyvaluejson/files/1_el.json
+++ b/openformats/tests/formats/structuredkeyvaluejson/files/1_el.json
@@ -1,0 +1,44 @@
+{
+  "singular_key": {
+    "string": "el:This is a regular string."
+  },
+  "total_files": {
+    "string": "{ item_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
+    "context": "Noun"
+  },
+  "special_chars": {
+    "string": "{ cnt, plural, one {el:This is Sam's book.} other {el:These are Sam's books.} }",
+    "developer_comment": "This is a string with special characters"
+  },
+  "gold_coins": {
+    "string": "{ count, plural,\n zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} \n}",
+    "character_limit": 150
+  },
+  "something": {
+    "else": {
+      "string": "el:Something else"
+    },
+    "is": {
+      "going_on": {
+        "string": "el:Something is going on."
+      },
+      "wrong": {
+        "string": "{ sth, plural, one {el:Something is wrong.} other {el:Somethings are wrong.} }"
+      }
+    }
+  },
+  "parent_key": {
+      "child_key": {
+        "string": "el:This is a key from a child",
+        "context": "Noun",
+        "developer_comment": "This is a comment.",
+        "character_limit": 150
+      }
+    },
+  "custom_plural_value": {
+    "string": "el:{number, plural, =1 {1 New}, =2 {# New}}"
+  },
+  "json_list": ["This is a regular string",
+                "This is a another string",
+                "This is the final string"]
+}

--- a/openformats/tests/formats/structuredkeyvaluejson/files/1_en.json
+++ b/openformats/tests/formats/structuredkeyvaluejson/files/1_en.json
@@ -1,0 +1,44 @@
+{
+  "singular_key": {
+    "string": "This is a regular string."
+  },
+  "total_files": {
+    "string": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
+    "context": "Noun"
+  },
+  "special_chars": {
+    "string": "{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }",
+    "developer_comment": "This is a string with special characters"
+  },
+  "gold_coins": {
+    "string": "{ count, plural,\n zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} \n}",
+    "character_limit": 150
+  },
+  "something": {
+    "else": {
+      "string": "Something else"
+    },
+    "is": {
+      "going_on": {
+        "string": "Something is going on."
+      },
+      "wrong": {
+        "string": "{ sth, plural, one {Something is wrong.} other {Somethings are wrong.} }"
+      }
+    }
+  },
+  "parent_key": {
+      "child_key": {
+        "string": "This is a key from a child",
+        "context": "Noun",
+        "developer_comment": "This is a comment.",
+        "character_limit": 150
+      }
+    },
+  "custom_plural_value": {
+    "string": "{number, plural, =1 {1 New}, =2 {# New}}"
+  },
+  "json_list": ["This is a regular string",
+                "This is a another string",
+                "This is the final string"]
+}

--- a/openformats/tests/formats/structuredkeyvaluejson/files/1_tpl.json
+++ b/openformats/tests/formats/structuredkeyvaluejson/files/1_tpl.json
@@ -1,0 +1,44 @@
+{
+  "singular_key": {
+    "string": "ab2800d7ccb83ba2d643174531d08e36_tr"
+  },
+  "total_files": {
+    "string": "{ item_count, plural, 4d0dfbc44762841c0cec988d1e18b4a6_pl }",
+    "context": "Noun"
+  },
+  "special_chars": {
+    "string": "{ cnt, plural, 00fe762ad9b56187fed536350bc3a40c_pl }",
+    "developer_comment": "This is a string with special characters"
+  },
+  "gold_coins": {
+    "string": "{ count, plural,\n 8060865280cf7fc9e80b79145208a825_pl \n}",
+    "character_limit": 150
+  },
+  "something": {
+    "else": {
+      "string": "27fc99812beff2126b12708a336513c8_tr"
+    },
+    "is": {
+      "going_on": {
+        "string": "38eb89d2562cc44ff2061a045b05ebca_tr"
+      },
+      "wrong": {
+        "string": "{ sth, plural, a125aead7129e03261500e0cade68557_pl }"
+      }
+    }
+  },
+  "parent_key": {
+      "child_key": {
+        "string": "aa1b6a1fd1c606a100f686af700ed34c_tr",
+        "context": "Noun",
+        "developer_comment": "This is a comment.",
+        "character_limit": 150
+      }
+    },
+  "custom_plural_value": {
+    "string": "ee829fd77061d65f1f18982a577b915b_tr"
+  },
+  "json_list": ["This is a regular string",
+                "This is a another string",
+                "This is the final string"]
+}

--- a/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
@@ -1,0 +1,405 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import six
+
+from openformats.formats.json import StructuredJsonHandler
+
+from openformats.exceptions import ParseError
+from openformats.strings import OpenString
+
+from openformats.tests.formats.common import CommonFormatTestMixin
+from openformats.tests.utils.strings import (generate_random_string,
+                                             bytes_to_string)
+
+
+class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
+
+    HANDLER_CLASS = StructuredJsonHandler
+    TESTFILE_BASE = "openformats/tests/formats/structuredkeyvaluejson/files"
+
+    def setUp(self):
+        super(StructuredJsonTestCase, self).setUp()
+
+        self.handler = StructuredJsonHandler()
+        self.random_string = generate_random_string()
+        self.pluralized_string = "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }" # noqa
+
+        self.random_openstring = OpenString("a",
+                                            self.random_string, order=0)
+        self.random_hash = self.random_openstring.template_replacement
+
+    def test_simple(self):
+        template, stringset = self.handler.parse('{"a": {"string":"%s"}}' %
+                                                 self.random_string)
+        compiled = self.handler.compile(template, [self.random_openstring])
+        self.assertEqual(template,
+                         '{"a": {"string":"%s"}}' % self.random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__,
+                         self.random_openstring.__dict__)
+        self.assertEqual(compiled,
+                         '{"a": {"string":"%s"}}' % self.random_string)
+
+    def test_embedded_dicts(self):
+        source = '{"a": {"b": {"string": "%s"}}}' % self.random_string
+        openstring = OpenString("a.b", self.random_string, order=0)
+        random_hash = openstring.template_replacement
+
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [openstring])
+
+        self.assertEqual(template,
+                         '{"a": {"b": {"string": "%s"}}}' % random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__, openstring.__dict__)
+        self.assertEqual(compiled, source)
+
+    def test_compile_ignores_removed_strings_for_dicts(self):
+        # The original JsonHandler, when compiling back from a template,
+        # removes any strings that are not passed as an argument in the
+        # compile() function. StructuredJsonHandler on the other hand, simply
+        # ignores those key-values and leave them as is in the template. This
+        # test ensures that this is the case.
+        # For more information, see _copy_until_and_remove_section() in both
+        # handlers.
+        string1 = self.random_string
+        string2 = generate_random_string()
+        openstring1 = self.random_openstring
+        openstring2 = OpenString("b", string2, order=1)
+        hash1 = self.random_hash
+        hash2 = openstring2.template_replacement
+
+        source = ('{"a": {"string":"%s"}, "b": {"string":"%s"}}' %
+                  (string1, string2))
+
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [openstring1])
+
+        self.assertEqual(template,
+                         '{"a": {"string":"%s"}, "b": {"string":"%s"}}' %
+                         (hash1, hash2))
+        self.assertEqual(len(stringset), 2)
+        self.assertEqual(stringset[0].__dict__, openstring1.__dict__)
+        self.assertEqual(stringset[1].__dict__, openstring2.__dict__)
+        self.assertEqual(
+            compiled,
+            '{"a": {"string":"%s"}, "b": {"string":"%s"}}' % (string1, hash2)
+        )
+
+    def test_invalid_json(self):
+        with self.assertRaises(ParseError) as context:
+            self.handler.parse(u'invalid_json')
+
+        self.assertIn(six.text_type(context.exception),
+                      ("Expecting value: line 1 column 1 (char 0)",
+                       "No JSON object could be decoded"))
+
+    def test_invalid_json_type(self):
+        template, stringset = self.handler.parse('[false]')
+        self.assertEqual(stringset, [])
+        self.assertEqual(template, '[false]')
+
+        template, stringset = self.handler.parse('{"false": false}')
+        self.assertEqual(stringset, [])
+        self.assertEqual(template, '{"false": false}')
+
+    def test_not_json_container(self):
+        self._test_parse_error('"hello"',
+                               'Was expecting whitespace or one of `[{` on '
+                               'line 1, found `"` instead')
+        self._test_parse_error('3',
+                               "Was expecting whitespace or one of `[{` on "
+                               "line 1, found `3` instead")
+        self._test_parse_error('false',
+                               "Was expecting whitespace or one of `[{` on "
+                               "line 1, found `f` instead")
+
+    def test_skipping_stuff_within_strings(self):
+        source = '{"a": {"string":"b,  ,c"}}'
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, stringset)
+        self.assertEqual(compiled, source)
+
+    def test_duplicate_keys(self):
+        self._test_parse_error('{"a": {"string": "hello"}, "a": {"string": "hello"}}', # noqa
+                               "Duplicate string key ('a') in line 1")
+
+    def test_display_json_errors(self):
+        self._test_parse_error('["]',
+                               "Unterminated string starting at: line 1 "
+                               "column 2 (char 1)")
+
+    def test_unescape(self):
+        cases = (
+            # simple => simple
+            ([u's', u'i', u'm', u'p', u'l', u'e'],
+             [u's', u'i', u'm', u'p', u'l', u'e']),
+            # hεllo => hεllo
+            ([u'h', u'ε', u'l', u'l', u'o'],
+             [u'h', u'ε', u'l', u'l', u'o']),
+            # h\u03b5llo => hεllo
+            ([u'h', u'\\', u'u', u'0', u'3', u'b', u'5', u'l', u'l', u'o'],
+             [u'h', u'ε', u'l', u'l', u'o']),
+            # a\"b => a"b
+            ([u'a', u'\\', u'"', u'b'], [u'a', u'"', u'b']),
+            # a\/b => a/b
+            ([u'a', u'\\', u'/', u'b'], [u'a', u'/', u'b']),
+            # a\/b => a?b, ? = BACKSPACE
+            ([u'a', u'\\', u'b', u'b'], [u'a', u'\b', u'b']),
+            # a\fb => a?b, ? = FORMFEED
+            ([u'a', u'\\', u'f', u'b'], [u'a', u'\f', u'b']),
+            # a\nb => a?b, ? = NEWLINE
+            ([u'a', u'\\', u'n', u'b'], [u'a', u'\n', u'b']),
+            # a\rb => a?b, ? = CARRIAGE_RETURN
+            ([u'a', u'\\', u'r', u'b'], [u'a', u'\r', u'b']),
+            # a\tb => a?b, ? = TAB
+            ([u'a', u'\\', u't', u'b'], [u'a', u'\t', u'b']),
+        )
+        for raw, rich in cases:
+            self.assertEqual(StructuredJsonHandler.unescape(
+                bytes_to_string(raw)), bytes_to_string(rich)
+            )
+
+    def test_escape(self):
+        cases = (
+            # simple => simple
+            ([u's', u'i', u'm', u'p', u'l', u'e'],
+             [u's', u'i', u'm', u'p', u'l', u'e']),
+            # hεllo => hεllo
+            ([u'h', u'ε', u'l', u'l', u'o'],
+             [u'h', u'ε', u'l', u'l', u'o']),
+            # h\u03b5llo => h\\u03b5llo
+            ([u'h', u'\\', u'u', u'0', u'3', u'b', u'5', u'l', u'l', u'o'],
+             [u'h', u'\\', u'\\', u'u', u'0', u'3', u'b', u'5', u'l', u'l',
+              u'o']),
+            # a"b =>a\"b
+            ([u'a', u'"', u'b'], [u'a', u'\\', u'"', u'b']),
+            # a/b =>a/b
+            ([u'a', u'/', u'b'], [u'a', u'/', u'b']),
+            # a?b =>a\/b, ? = BACKSPACE
+            ([u'a', u'\b', u'b'], [u'a', u'\\', u'b', u'b']),
+            # a?b =>a\fb, ? = FORMFEED
+            ([u'a', u'\f', u'b'], [u'a', u'\\', u'f', u'b']),
+            # a?b =>a\nb, ? = NEWLINE
+            ([u'a', u'\n', u'b'], [u'a', u'\\', u'n', u'b']),
+            # a?b =>a\rb, ? = CARRIAGE_RETURN
+            ([u'a', u'\r', u'b'], [u'a', u'\\', u'r', u'b']),
+            # a?b => a\tb, ? = TAB
+            ([u'a', u'\t', u'b'], [u'a', u'\\', u't', u'b']),
+        )
+        for rich, raw in cases:
+            self.assertEqual(StructuredJsonHandler.escape(
+                bytes_to_string(rich)), bytes_to_string(raw)
+            )
+
+    # PLURALS
+
+    def test_invalid_plural_format(self):
+        # Test various cases of messed-up braces
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, one {You have {file_count file.} other {You have {file_count} files.} }" }}',  # noqa
+            'Invalid format of pluralized entry with key: "total_files.string"'
+        )
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, one {You have file_count} file.} other {You have {file_count} files.} }" }}',  # noqa
+            'Invalid format of pluralized entry with key: "total_files.string"'
+        )
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, one {You have {file_count} file. other {You have {file_count} files.} }" }}',  # noqa
+            'Invalid format of pluralized entry with key: "total_files.string"'
+        )
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, one {You have {file_count} file}. other {You have file_count} files.} }" }}',  # noqa
+            'Invalid format of pluralized entry with key: "total_files.string"'
+        )
+
+    def test_invalid_plural_rules(self):
+        # Only the following strings are allowed as plural rules:
+        #   zero, one, few, many, other
+        # Anything else, including their TX int equivalents are invalid.
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, 1 {file} 5 {{file_count} files} }" }}',  # noqa
+            'Invalid plural rule(s): "1, 5" in pluralized entry with key: total_files.string'  # noqa
+        )
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, once {file} mother {{file_count} files} }" }}',  # noqa
+            'Invalid plural rule(s): "once, mother" in pluralized entry with key: total_files.string'  # noqa
+        )
+        self._test_parse_error_message(
+            '{ "total_files": {"string": "{ item_count, plural, =3 {file} other {{file_count} files} }" }}',  # noqa
+            'Invalid plural rule(s): "=3" in pluralized entry with key: total_files.string'  # noqa
+        )
+
+    def test_irrelevant_whitespace_ignored(self):
+        # Whitespace between the various parts of the message format structure
+        # should be ignored.
+        expected_translations = {0: 'Empty', 5: '{count} files'}
+
+        self._test_translations_equal(
+            '{'
+            '    "k": {"string": "{ cnt, plural, zero {Empty} other {{count} files} }"}' # noqa
+            '}',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{'
+            '    "k": {"string": "{cnt,plural,zero{Empty}other{{count} files} }"}' # noqa
+            '}',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{ "k": {"string": "{    cnt,  plural,     zero  {Empty} other   {{count} files} }   "     }}',  # noqa
+            expected_translations
+        )
+        self._test_translations_equal(
+            '     {'
+            '    "k": {"string": "{cnt,plural,zero{Empty}other{{count} files} }"}' # noqa
+            '}  ',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{'
+            '    "k": {"string": "  {cnt, plural, zero {Empty} other {{count} files} }"}' # noqa
+            '}',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{'
+            '    "k": {"string": "{cnt , plural , zero {Empty} other {{count} files} }"}' # noqa
+            '}',
+            expected_translations
+        )
+
+        # Escaped new lines should be allowed
+        self._test_translations_equal(
+            '{'
+            '    "k": {"string": "{cnt, plural,\\n zero {Empty} other {{count} files} \\n}"}'  # noqa
+            '}',
+            expected_translations
+        )
+
+        # Rendering a template with escaped new lines should work. However,
+        # these characters cannot be inside the pluralized string, because the
+        # template would be very hard to create in that case (e.g. not allowed
+        # in: 'zero {Empty} \n other {{count} files}'
+        source = '{"a": {"string": "{cnt, plural,\\n one {0} other {{count} files} \\n}"}}' # noqa
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, stringset)
+        self.assertEqual(compiled, source)
+
+    def test_non_supported_icu_argument(self):
+        # Non-supported ICU arguments (everything other than `plural`)
+        # should make a string be treated as non-pluralized
+
+        string = '{"k": {"string" :"{ gender_of_host, select, female {{host} appeared} male {{host} appeared} }"}}'  # noqa
+        _, stringset = self.handler.parse(string)
+
+        self.assertEqual(
+            stringset[0].string,
+            '{ gender_of_host, select, female {{host} appeared} male {{host} appeared} }' # noqa
+        )
+
+    def test_nesting_with_plurals(self):
+        expected_translations = {0: 'Empty', 5: '{count} files'}
+
+        self._test_translations_equal(
+            '{ "k": { "a": {"string" :"{ cnt, plural, zero {Empty} other {{count} files} }", "b": "c" } }}',  # noqa
+            expected_translations
+        )
+
+    def test_whitespace_in_translations_not_ignored(self):
+        # Whitespace between the various parts of the message format structure
+        # should be ignored.
+        self._test_translations_equal(
+            '{"k": {"string": "{ cnt, plural, zero { Empty} other {{count} files} }"}}', # noqa
+            {0: ' Empty', 5: '{count} files'}
+        )
+        self._test_translations_equal(
+            '{"k": {"string": "{ cnt, plural, zero { Empty  } other {{count} files } }"}}', # noqa
+            {0: ' Empty  ', 5: '{count} files '}
+        )
+
+    def test_openstring_structure(self):
+        _, stringset = self.handler.parse(
+            '{"a": {"string":"%s", "developer_comment": "developer_comment",'
+            '"character_limit": 150, "context": "context"}}'
+            % self.random_string
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].string, self.random_string)
+        self.assertEqual(stringset[0].developer_comment, "developer_comment")
+        self.assertEqual(stringset[0].character_limit, 150)
+        self.assertEqual(stringset[0].context, "context")
+
+    def test_openstring_structure_with_nested_format(self):
+        _, stringset = self.handler.parse(
+            '{"a": {"level": {"string":"%s", "developer_comment": "developer_comment",' # noqa
+            '"character_limit": 150, "context": "context"}}}'
+            % self.random_string
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].string, self.random_string)
+        self.assertEqual(stringset[0].developer_comment, "developer_comment")
+        self.assertEqual(stringset[0].developer_comment, "developer_comment")
+        self.assertEqual(stringset[0].character_limit, 150)
+        self.assertEqual(stringset[0].context, "context")
+
+    def test_openstring_structure_with_default_values(self):
+        _, stringset = self.handler.parse(
+            '{"a": {"string":"%s"}}' % self.random_string
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].string, self.random_string)
+        self.assertEqual(stringset[0].developer_comment, "")
+        self.assertEqual(stringset[0].character_limit, None)
+        self.assertEqual(stringset[0].context, "")
+
+    def test_pluralized_openstring_structure(self):
+        _, stringset = self.handler.parse(
+            '{"a": {"string":"%s", "developer_comment": "developer_comment",'
+            '"character_limit": 150, "context": "context"}}'
+            % self.pluralized_string
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].developer_comment, "developer_comment")
+        self.assertEqual(stringset[0].character_limit, 150)
+        self.assertEqual(stringset[0].context, "context")
+
+    def test_pluralized_openstring_structure_with_nested_format(self):
+        _, stringset = self.handler.parse(
+            '{"a": {"level": {"string":"%s", "developer_comment": "developer_comment",' # noqa
+            '"character_limit": 150, "context": "context"}}}'
+            % self.pluralized_string
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].developer_comment, "developer_comment")
+        self.assertEqual(stringset[0].developer_comment, "developer_comment")
+        self.assertEqual(stringset[0].character_limit, 150)
+        self.assertEqual(stringset[0].context, "context")
+
+    def test_pluralized_openstring_structure_with_default_values(self):
+        _, stringset = self.handler.parse(
+            '{"a": {"string":"%s"}}' % self.pluralized_string
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].developer_comment, "")
+        self.assertEqual(stringset[0].character_limit, None)
+        self.assertEqual(stringset[0].context, "")
+
+    def _test_parse_error_message(self, source, msg_substr):
+        error_raised = False
+        try:
+            self.handler.parse(source)
+        except ParseError as e:
+            self.assertIn(msg_substr, six.text_type(e))
+            error_raised = True
+        self.assertTrue(error_raised)
+
+    def _test_translations_equal(self, source, translations_by_rule):
+        template, stringset = self.handler.parse(source)
+        for rule_int in six.iterkeys(translations_by_rule):
+            self.assertEqual(
+                translations_by_rule[rule_int],
+                stringset[0].string[rule_int]
+            )


### PR DESCRIPTION
Problem and/or solution
-----------------------
Customers needed a way to combine the functionality of two different file formats, KEYVALUEJSON and CHROME. The first supports ICU out of the box while the latter supports developer comments.

The new suggested format, is a structured JSON one, which extends the original JSON handler (keeping most of its functionality like ICU support), while it preserves certain keys for internal usage in Txc (like `developer_notes` and `context`).

How to test
-----------
 Fire up the testbed instance in order to run manual tests. You can use the file in `openformats/tests/formats/structuredkeyvaluejson/files/1_en.json` for a few examples with plurals and nested JSON objects.

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
