### PR TITLE
Po download obsoleted strings fix

### DIFF
--- a/openformats/tests/formats/po/test_po.py
+++ b/openformats/tests/formats/po/test_po.py
@@ -78,6 +78,62 @@ class PoTestCase(CommonFormatTestMixin, unittest.TestCase):
             u'python-format, another-flag'
         )
 
+    def test_compiled_includes_all_with_obsoleted_strings(self):
+        """
+        Test that the existence of obsoleted strings in the po file
+        marked with #~ does not cause strings after the obsoleted ones
+        to be missing from the compiled file.
+        """
+        string1 = self._create_openstring(False)
+        string2 = self._create_openstring(False)
+        string3 = self._create_openstring(False)
+        source = strip_leading_spaces(u"""
+            msgid ""
+            msgstr ""
+            
+            msgid "{s1_key}"
+            msgstr "{s1_str}"
+            
+            #~ msgid "{s2_key}"
+            #~ msgstr "{s2_str}"
+            
+            msgid "{s3_key}"
+            msgstr "{s3_str}"
+        """.format(**{
+            's1_key': string1.key,
+            's1_str': string1.string,
+            's2_key': string2.key,
+            's2_str': string2.string,
+            's3_key': string3.key,
+            's3_str': string3.string
+        }))
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [string1, string2, string3])
+
+        self.assertEqual(
+            compiled,
+            strip_leading_spaces(
+                u"""# \nmsgid ""
+                msgstr ""
+                
+                msgid "{s1_key}"
+                msgstr "{s1_str}"
+                
+                #~ msgid "{s2_key}"
+                #~ msgstr "{s2_str}"
+                
+                msgid "{s3_key}"
+                msgstr "{s3_str}"
+                """.format(**{
+                    's1_key': string1.key,
+                    's1_str': string1.string,
+                    's2_key': string2.key,
+                    's2_str': string2.string,
+                    's3_key': string3.key,
+                    's3_str': string3.string
+                }))
+        )
+
     def test_removes_untranslated_non_pluralized(self):
         string1 = self._create_openstring(False)
         string2 = self._create_openstring(False)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
 
 setup(
     name="openformats",
-    version='0.0.47',
+    version='0.0.51',
     description="The Transifex Open Formats library",
     author="Transifex",
     author_email="support@transifex.com",


### PR DESCRIPTION
Problem and/or solution
-----------------------
When uploading a PO file in Resources, if obsoleted strings (marked with `#~`) are part of the file, due to the separate handling of obsolete and non obsolete entries in polib, the template generated at PO file handler's parsing has different order than the strings in the original file. Thus, the information saved in the database and as a consequence in the exported file, misses any non obsoleted strings that follow the obsoleted ones.

As a solution, we by pass the polib.POFile 's __unicode__() method by not generating the template using six.text_type(po_file) and instead provide a method in PoHandler that generates the template without changing the order when obsoleted string are present.

How to test
-----------

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
