### PR TITLE
Adds `EXTRACT_RAW` flag on markdown handler

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -145,6 +145,7 @@ class TxBlockLexer(BlockLexer):
 class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
     name = "Github_Markdown"
     extension = "md"
+    EXTRACTS_RAW = False
 
     # Translatable YAML header attributes
     YAML_ATTR = (u'title', u'description')


### PR DESCRIPTION
Problem and/or solution
-----------------------

The flag `EXTRACT_RAW` indicates a different behavior based on
the format. The default value of the flag is `True`, which means
that the contents of the file are extracted as is with the
escaping rules defined. In consequence if the flag is `True`
the following methods should be present: `escape`/`unescape`.

Markdown handler does not fall under this category so the
flag should be overriden to `False`.

How to test
-----------

No change in the parsing of markdown files should be observed.

Reviewer checklist
------------------

Code:
* N/A Change is covered by unit-tests
* N/A Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
