### PR TITLE
openformats update (0.0.54)

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -145,6 +145,7 @@ class TxBlockLexer(BlockLexer):
 class GithubMarkdownHandler(OrderedCompilerMixin, Handler):
     name = "Github_Markdown"
     extension = "md"
+    EXTRACTS_RAW = False
 
     # Translatable YAML header attributes
     YAML_ATTR = (u'title', u'description')

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
 
 setup(
     name="openformats",
-    version='0.0.53',
+    version='0.0.54',
     description="The Transifex Open Formats library",
     author="Transifex",
     author_email="support@transifex.com",


### PR DESCRIPTION

Merged Pull Requests:

* transifex/openformats#151 - Bumps version to 0.0.54
* transifex/openformats#150 - Adds `EXTRACT_RAW` flag on markdown handler
