### PR TITLE
Added chrome v3 handler

### DIFF
--- a/openformats/tests/formats/chromev3/files/1_el.json
+++ b/openformats/tests/formats/chromev3/files/1_el.json
@@ -1,0 +1,31 @@
+{
+  "simple": {
+    "message": "el:simple message"
+  },
+  "with description": {
+    "message": "el:simple message",
+    "description": "simple description"
+  },
+  "description not a string": {
+    "message": "el:simple message",
+    "description": 3
+  },
+  "not a dictionary": 3,
+  "not a dictionary v2": [3],
+  "message not a string": {
+    "message": 3
+  },
+  "with extra stuff": {
+    "message": "el:simple message",
+    "placeholders": {
+      "a": 1,
+      "b": 2
+    }
+  },
+  "key.with.dots": {
+    "message": "el:simple message"
+  },
+  "pluralized": {
+    "message": "{cnt, plural, one {el:horse} other {el:horses}}"
+  }
+}

--- a/openformats/tests/formats/chromev3/files/1_en.json
+++ b/openformats/tests/formats/chromev3/files/1_en.json
@@ -1,0 +1,31 @@
+{
+  "simple": {
+    "message": "simple message"
+  },
+  "with description": {
+    "message": "simple message",
+    "description": "simple description"
+  },
+  "description not a string": {
+    "message": "simple message",
+    "description": 3
+  },
+  "not a dictionary": 3,
+  "not a dictionary v2": [3],
+  "message not a string": {
+    "message": 3
+  },
+  "with extra stuff": {
+    "message": "simple message",
+    "placeholders": {
+      "a": 1,
+      "b": 2
+    }
+  },
+  "key.with.dots": {
+    "message": "simple message"
+  },
+  "pluralized": {
+    "message": "{cnt, plural, one {horse} other {horses}}"
+  }
+}

--- a/openformats/tests/formats/chromev3/files/1_tpl.json
+++ b/openformats/tests/formats/chromev3/files/1_tpl.json
@@ -1,0 +1,31 @@
+{
+  "simple": {
+    "message": "f39e4a122e9a8c8e9b398aa9a7003bee_tr"
+  },
+  "with description": {
+    "message": "1f6c3d7ca32998ebb32189701c33b596_tr",
+    "description": "simple description"
+  },
+  "description not a string": {
+    "message": "8a3a0089b0ddfbba3e04cc7a4e847022_tr",
+    "description": 3
+  },
+  "not a dictionary": 3,
+  "not a dictionary v2": [3],
+  "message not a string": {
+    "message": 3
+  },
+  "with extra stuff": {
+    "message": "87ca036cc1ecbea02075c5be9c93d530_tr",
+    "placeholders": {
+      "a": 1,
+      "b": 2
+    }
+  },
+  "key.with.dots": {
+    "message": "e5c58379e175c372ca6e7b0efa9b5a76_tr"
+  },
+  "pluralized": {
+    "message": "{cnt, plural, ea4101a387e08dd12345e43f3f389c9a_pl}"
+  }
+}

--- a/openformats/tests/formats/chromev3/test_chrome_v3.py
+++ b/openformats/tests/formats/chromev3/test_chrome_v3.py
@@ -1,0 +1,110 @@
+from __future__ import unicode_literals
+
+import json
+import unittest
+
+from openformats.exceptions import ParseError
+from openformats.formats.json import ChromeI18nHandlerV3
+from openformats.strings import OpenString
+from openformats.tests.formats.common import CommonFormatTestMixin
+from openformats.tests.utils.strings import generate_random_string
+
+
+class ChromeI18nV3TestCase(CommonFormatTestMixin, unittest.TestCase):
+    HANDLER_CLASS = ChromeI18nHandlerV3
+    TESTFILE_BASE = "openformats/tests/formats/chromev3/files"
+
+    def setUp(self):
+        super(ChromeI18nV3TestCase, self).setUp()
+        self.random_string = generate_random_string()
+        self.random_openstring = OpenString('a', self.random_string, order=0,
+                                            developer_comment='')
+
+    def test_simple(self):
+        source_template = '{"a": {"message": "%s"}}'
+        source = source_template % self.random_string
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [self.random_openstring])
+
+        self.assertEqual(
+            template,
+            source_template % self.random_openstring.template_replacement
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__,
+                         self.random_openstring.__dict__)
+        self.assertEqual(compiled, source)
+        # Check developer comment is empty
+        self.assertEqual(stringset[0].developer_comment, '')
+
+    def test_invalid_json(self):
+        with self.assertRaises(ParseError):
+            self.handler.parse('{')
+        with self.assertRaises(ParseError):
+            self.handler.parse('3')
+        self._test_parse_error('[]', u"Source file must be a JSON object")
+
+    def test_double_key(self):
+        self._test_parse_error('{"a": 1, "a": 2}',
+                               u"Key 'a' appears multiple times (line 1)")
+
+    def test_pluralized_string(self):
+        source_template = '{"a": {"message": "{cnt, plural, %s}"}}'
+        source = source_template % "one {horse} other {horses}"
+        openstring = OpenString('a', {1: "horse", 5: "horses"},
+                                pluralized=True, order=0, developer_comment='')
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [openstring])
+
+        self.assertEqual(template,
+                         source_template % openstring.template_replacement)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__, openstring.__dict__)
+        self.assertEqual(compiled, source)
+        # Check developer comment is empty
+        self.assertEqual(stringset[0].developer_comment, '')
+
+    def test_remove_strings(self):
+        """ Start with a source file with 3 strings and test the parsing
+            process as always. Then compile it 3 times. Each time, as the
+            stringset use 2 of the 3 original strings. Make sure the compiled
+            file is a valid JSON string and that it only includes the strings
+            that were in the stringset.
+        """
+
+        source_template = ('{"a": {"message": "%s"}, "b": {"message": "%s"},'
+                           ' "c": {"message": "%s"}}')
+        source = source_template % ("aaa", "bbb", "ccc")
+        openstring_a = OpenString('a', "aaa", order=0, developer_comment='')
+        openstring_b = OpenString('b', "bbb", order=1, developer_comment='')
+        openstring_c = OpenString('c', "ccc", order=2, developer_comment='')
+        template, stringset = self.handler.parse(source)
+
+        self.assertEqual(template,
+                         source_template % (openstring_a.template_replacement,
+                                            openstring_b.template_replacement,
+                                            openstring_c.template_replacement))
+        self.assertEqual(len(stringset), 3)
+        self.assertEqual([string.__dict__ for string in stringset],
+                         [openstring_a.__dict__,
+                          openstring_b.__dict__,
+                          openstring_c.__dict__])
+
+        # We will compare the dict versions of the strings because the way the
+        # compiler leaves over some whitespaces when removing sections makes
+        # the serialized versions a bit unpredictable
+
+        # Remove first string
+        compiled = self.handler.compile(template, [openstring_b, openstring_c])
+        self.assertEqual(json.loads(compiled),
+                         {'b': {'message': "bbb"}, 'c': {'message': "ccc"}})
+
+        # Remove second string
+        compiled = self.handler.compile(template, [openstring_a, openstring_c])
+        self.assertEqual(json.loads(compiled),
+                         {'a': {'message': "aaa"}, 'c': {'message': "ccc"}})
+
+        # Remove third string
+        compiled = self.handler.compile(template, [openstring_a, openstring_b])
+        self.assertEqual(json.loads(compiled),
+                         {'a': {'message': "aaa"}, 'b': {'message': "bbb"}})

--- a/openformats/tests/util_tests/test_json.py
+++ b/openformats/tests/util_tests/test_json.py
@@ -88,6 +88,24 @@ class DumbJsonTestCase(unittest.TestCase):
         self._test_dfs('{"a": "hello world\\\\"}',
                        [('a', 2, 'hello world\\\\', 7)])
 
+    # find_children
+    def test_find_children(self):
+        test_cases = [
+            ('{"a": "aaa"}', [], []),
+            ('{"a": "aaa"}', ['a'], [('aaa', 7)]),
+            ('{"a": "aaa"}', ['b'], [(None, None)]),
+            ('{"a": "aaa", "b": "bbb"}', [], []),
+            ('{"a": "aaa", "b": "bbb"}', ['a'], [('aaa', 7)]),
+            ('{"a": "aaa", "b": "bbb"}', ['b'], [('bbb', 19)]),
+            ('{"a": "aaa", "b": "bbb"}', ['a', 'b'],
+             [('aaa', 7), ('bbb', 19)]),
+            ('{"a": "aaa", "b": "bbb"}', ['a', 'c'],
+             [('aaa', 7), (None, None)]),
+        ]
+        for source, keys, expected_result in test_cases:
+            self.assertEqual(DumbJson(source).find_children(*keys),
+                             expected_result)
+
     # Utils
     def _test_dfs(self, content, against):
         dumb_json = DumbJson(content)

--- a/openformats/utils/json.py
+++ b/openformats/utils/json.py
@@ -274,6 +274,31 @@ class DumbJson(object):
     def end(self, value):
         self._end = value
 
+    def find_children(self, *keys):
+        """
+            Get values (and positions) of a DumbJson dict. Usage:
+
+                >>> jj = DumbJson('{"a": "aaa", "b": "bbb"}')
+
+                >>> (a, a_pos), (c, c_pos) = jj.find_children('a', 'c')
+                >>> print(a, a_pos, c, c_pos)
+                <<< 'aaa', 7, None, None
+
+                >>> # Notice the trailing comma (`,`)
+                >>> (a, a_pos), = jj.find_children('a')
+                >>> print(a, a_pos)
+                <<< 'aaa', 7
+
+            :return: a list of 2-tuples with values and value positions
+            :rtype: list
+        """
+
+        found = {}
+        for key, key_position, value, value_position in self:
+            if key in keys:
+                found[key] = (value, value_position)
+        return [(found.get(key, (None, None))) for key in keys]
+
 
 for symbol in (DumbJson.BACKSLASH, DumbJson.DOUBLE_QUOTES,
                DumbJson.FORWARD_SLASH, DumbJson.BACKSPACE, DumbJson.FORMFEED,


### PR DESCRIPTION
Problem and/or solution
-----------------------

The previous Chrome handler had a few issues:

1. It allowed for chrome json files to have nested objects. This isn't necessary; chrome files always have strings as the key-value pairs of the root object
2. It escaped `.` symbols in keys. This would be necessary if nesting was supported but since it isn't, we can simply use the JSON keys as keys
3. It appended `.message` to the keys. This is weird and unnecessary
4. It couldn't find the `description` part of strings if the key had a `.` in it.

All these issues have been addressed with this new implementation

How to test
-----------

Play with the testbed (a sample file will load once you pick the v3 handler) and/or run the tests

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
