### PR TITLE
Add un/escaping to Chrome v3 handler

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -13,7 +13,7 @@ from ..handlers import Handler
 from ..strings import OpenString
 from ..transcribers import Transcriber
 from ..utils.icu import ICUCompiler, ICUParser
-from ..utils.json import DumbJson
+from ..utils.json import DumbJson, escape, unescape
 
 
 class JsonHandler(Handler):
@@ -402,108 +402,13 @@ class JsonHandler(Handler):
         except IndexError:
             return None
 
-    @classmethod
-    def escape(cls, string):
-        return u''.join(cls._escape_generator(string))
-        # btw, this seems equivalent to
-        # return json.dumps(string, ensure_ascii=False)[1:-1]
+    @staticmethod
+    def escape(string):
+        return escape(string)
 
     @staticmethod
-    def _escape_generator(string):
-        for symbol in string:
-            if symbol == DumbJson.DOUBLE_QUOTES:
-                yield DumbJson.BACKSLASH
-                yield DumbJson.DOUBLE_QUOTES
-            elif symbol == DumbJson.BACKSLASH:
-                yield DumbJson.BACKSLASH
-                yield DumbJson.BACKSLASH
-            elif symbol == DumbJson.BACKSPACE:
-                yield DumbJson.BACKSLASH
-                yield u'b'
-            elif symbol == DumbJson.FORMFEED:
-                yield DumbJson.BACKSLASH
-                yield u'f'
-            elif symbol == DumbJson.NEWLINE:
-                yield DumbJson.BACKSLASH
-                yield u'n'
-            elif symbol == DumbJson.CARRIAGE_RETURN:
-                yield DumbJson.BACKSLASH
-                yield u'r'
-            elif symbol == DumbJson.TAB:
-                yield DumbJson.BACKSLASH
-                yield u't'
-            else:
-                yield symbol
-
-    @classmethod
-    def unescape(cls, string):
-        return u''.join(cls._unescape_generator(string))
-        # btw, this seems equivalent to
-        # return json.loads(u'"{}"'.format(string))
-
-    @staticmethod
-    def _unescape_generator(string):
-        # I don't like this aldschool approach, but we may have to rewind a bit
-        ptr = 0
-        while True:
-            if ptr >= len(string):
-                break
-
-            symbol = string[ptr]
-
-            if symbol != DumbJson.BACKSLASH:
-                yield symbol
-                ptr += 1
-                continue
-
-            try:
-                next_symbol = string[ptr + 1]
-            except IndexError:
-                yield DumbJson.BACKSLASH
-                ptr += 1
-                continue
-
-            if next_symbol in (DumbJson.DOUBLE_QUOTES, DumbJson.FORWARD_SLASH,
-                               DumbJson.BACKSLASH):
-                yield next_symbol
-                ptr += 2
-            elif next_symbol == u'b':
-                yield DumbJson.BACKSPACE
-                ptr += 2
-            elif next_symbol == u'f':
-                yield DumbJson.FORMFEED
-                ptr += 2
-            elif next_symbol == u'n':
-                yield DumbJson.NEWLINE
-                ptr += 2
-            elif next_symbol == u'r':
-                yield DumbJson.CARRIAGE_RETURN
-                ptr += 2
-            elif next_symbol == u't':
-                yield DumbJson.TAB
-                ptr += 2
-            elif next_symbol == u'u':
-                unicode_escaped = string[ptr:ptr + 6]
-                try:
-                    unescaped = unicode_escaped.\
-                        encode('ascii').\
-                        decode('unicode-escape')
-                except Exception:
-                    yield DumbJson.BACKSLASH
-                    yield u'u'
-                    ptr += 2
-                    continue
-                if len(unescaped) != 1:
-                    yield DumbJson.BACKSLASH
-                    yield u'u'
-                    ptr += 2
-                    continue
-                yield unescaped
-                ptr += 6
-
-            else:
-                yield symbol
-                ptr += 1
+    def unescape(string):
+        return unescape(string)
 
 
 class StructuredJsonHandler(JsonHandler):
@@ -1007,3 +912,11 @@ class ChromeI18nHandlerV3(Handler):
         compiled = re.sub(r',(\s*)}(\s*)$', r'\1}\2', compiled)
 
         return compiled
+
+    @staticmethod
+    def escape(string):
+        return escape(string)
+
+    @staticmethod
+    def unescape(string):
+        return unescape(string)


### PR DESCRIPTION
Problem and/or solution
-----------------------

We kind of forgot last time. The same un/escaping rules apply as with
any JSON-based handler, so I moved the un/escape functions to a utils
module and used it in both the old handlers and the new one.

How to test
-----------

Running the test-suite makes sure that un/escaping works for the old handlers so it should be enough.

Reviewer checklist
------------------

Code:
* N/A Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
