### PR TITLE
Set `EXTRACTS_RAW` to `False` for indesign format

### DIFF
--- a/openformats/formats/indesign.py
+++ b/openformats/formats/indesign.py
@@ -27,6 +27,7 @@ class InDesignHandler(Handler):
     extension = "idml"
     SPECIFIER = None
     PROCESSES_BINARY = True
+    EXTRACTS_RAW = False
 
     # The ? at the end of the string regex, makes it non-greedy in order to
     # allow trailing spaces to be preserved

--- a/openformats/formats/plaintext.py
+++ b/openformats/formats/plaintext.py
@@ -11,6 +11,7 @@ from ..utils.compilers import OrderedCompilerMixin
 class PlaintextHandler(OrderedCompilerMixin, Handler):
     name = "Plaintext"
     extension = "txt"
+    EXTRACTS_RAW = False
 
     def parse(self, content, **kwargs):
         stringset = []

--- a/openformats/formats/srt.py
+++ b/openformats/formats/srt.py
@@ -9,6 +9,7 @@ from openformats.transcribers import Transcriber
 class SrtHandler(Handler):
     name = "SRT"
     extension = "srt"
+    EXTRACTS_RAW = False
 
     NON_SPACE_PAT = re.compile(r'[^\s]')
 

--- a/openformats/tests/formats/common/__init__.py
+++ b/openformats/tests/formats/common/__init__.py
@@ -57,6 +57,11 @@ class CommonFormatTestMixin(object):
         self.tmpl, self.strset = self.handler.parse(self.data["1_en"])
         super(CommonFormatTestMixin, self).setUp()
 
+    def test_extracts_raw(self):
+        if self.HANDLER_CLASS.EXTRACTS_RAW:
+            self.assertTrue(hasattr(self.HANDLER_CLASS, 'escape'))
+            self.assertTrue(hasattr(self.HANDLER_CLASS, 'unescape'))
+
     def test_template(self):
         """Test that the template created is the same as static one."""
         # FIXME: Test descriptions should have the handler's name prefixed to

--- a/openformats/tests/formats/indesign/test_indesign.py
+++ b/openformats/tests/formats/indesign/test_indesign.py
@@ -27,6 +27,11 @@ class InDesignTestCase(unittest.TestCase):
                          [hash(string) for string in stringset2])
         self.assertEqual(template, template2)
 
+    def test_extracts_raw(self):
+        if self.HANDLER_CLASS.EXTRACTS_RAW:
+            self.assertTrue(hasattr(self.HANDLER_CLASS, 'escape'))
+            self.assertTrue(hasattr(self.HANDLER_CLASS, 'unescape'))
+
     def test_parser(self):
         """Test parsing to template and validate template."""
 


### PR DESCRIPTION
Problem and/or solution
-----------------------

The flag `EXTRACTS_RAW` defaults to `True`.
When `EXTRACT_RAW` is set to `True` the handler must
also provide the `escape` and `unescaped` staticmethods.
These methods are necessary in order to convert the
parsed content (escaped aka `raw`) to unescaped (`rich`)
and back.

Some handlers does not override the default value
nor provide the necesseray methods. Since the parsed
content for those handlers is unescaped,
the `EXTRACTS_RAW` flag should be set to `False`.

Adds unit test to verify the above behavior for
all Handlers.

How to test
-----------

Added unit test to verify the above behavior for
all Handlers.

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
