### PR TITLE
Escape control characters on compile

### DIFF
--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -5,6 +5,8 @@ import re
 import six
 
 from mistune import Markdown
+from yaml.reader import Reader
+
 from openformats.formats.github_markdown import TxBlockLexer, string_handler
 from openformats.formats.yaml import YamlHandler
 from openformats.utils.compat import ensure_unicode
@@ -14,6 +16,17 @@ from ..strings import OpenString
 from ..transcribers import Transcriber
 from ..utils.compilers import OrderedCompilerMixin
 from ..utils.newlines import find_newline_type, force_newline_type
+
+
+def escape(string):
+    return u''.join(_escape_generator(string))
+
+
+def _escape_generator(string):
+    for symbol in string:
+        if symbol == 'd':
+            yield u'"'
+            yield u'x'
 
 
 class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
@@ -39,15 +52,16 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         transcriber = Transcriber(template)
         template = transcriber.source
 
-        for string in stringset:
-            tr_string = string.string
-            if self._is_yaml_string(string):
-                tr_string = self._transform_yaml_string(string)
+        for openstring in stringset:
+            tr_string = openstring.string
+            if self._is_yaml_string(openstring):
+                self._escape_invalid_chars(openstring)
+                tr_string = self._transform_yaml_string(openstring)
 
-            hash_position = template.index(string.template_replacement)
+            hash_position = template.index(openstring.template_replacement)
             transcriber.copy_until(hash_position)
             transcriber.add(tr_string)
-            transcriber.skip(len(string.template_replacement))
+            transcriber.skip(len(openstring.template_replacement))
 
         transcriber.copy_until(len(template))
         compiled = transcriber.get_destination()
@@ -76,6 +90,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         yaml_template = ''
         seperator = ''
         if yml_header:
+            import ipdb; ipdb.set_trace()
             yaml_header_content = ''.join(yml_header.group(1, 2))
             seperator = yml_header.group(3)
             md_content = content[len(yaml_header_content + seperator):]
@@ -136,6 +151,28 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
             return True
 
         return False
+
+    def _escape_invalid_chars(self, openstring):
+        """Escape any invalid characters in the given string.
+
+        Modifies the given OpenString object in place, checking strings for all
+        plural rules.
+
+        :param OpenString openstring: the string object to check
+        """
+        # Check each plural rule of the string
+        for rule, string in openstring._strings.iteritems():
+            chars = []
+            # Go through each character
+            # If a control character is found (e.g. backspace)
+            # escape it to a unicode format, e.g. \u0008
+            for x in string:
+                if Reader.NON_PRINTABLE.match(x):
+                    chars.append('\\u{:04d}'.format(ord(x)))
+                else:
+                    chars.append(x)
+
+            openstring._strings[rule] = u"".join(chars)
 
     def _transform_yaml_string(self, openstring):
         """Transform the given YAML-formatted string to make it valid for compilation.

--- a/openformats/tests/formats/github_markdown_v2/files/1_el.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_el.md
@@ -183,6 +183,9 @@ el:This is as reference [link][1].
 "[el:Reference]: http://example.com/"
 
 
+# Escaping
+el:The next char here is the backspace control character ->\u0008<- (but you can't see it)
+
 # el:Special section
 el:WARNING! The example shown here seems to break all tests on content that is below the javascript code block, because of the "el:" part that is added before the code block notation. Please keep this at the end of the file.  
 

--- a/openformats/tests/formats/github_markdown_v2/files/1_en.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en.md
@@ -186,6 +186,9 @@ This is as reference [link][1].
 "[Reference]: http://example.com/"
 
 
+# Escaping
+The next char here is the backspace control character -><- (but you can't see it)
+
 # Special section
 WARNING! The example shown here seems to break all tests on content that is below the javascript code block, because of the "el:" part that is added before the code block notation. Please keep this at the end of the file.  
 

--- a/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
@@ -182,6 +182,9 @@ This is as reference [link][1].
 "[Reference]: http://example.com/"
 
 
+# Escaping
+The next char here is the backspace control character -><- (but you can't see it)
+
 # Special section
 WARNING! The example shown here seems to break all tests on content that is below the javascript code block, because of the "el:" part that is added before the code block notation. Please keep this at the end of the file.  
 

--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -137,3 +137,14 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
         openstring = OpenString('k', u' @κάπου')
         string = self.handler._transform_yaml_string(openstring)
         self.assertEqual(string, u'" @κάπου"')
+
+    def test_escape_control_characters(self):
+        openstring = OpenString('k', u'者・最')  # 2nd character is the backspace char
+        self.handler._escape_invalid_chars(openstring)
+        self.assertEqual(openstring.string, u'者\u0008・最')
+
+        openstring = OpenString('k', {5: u'者・最', 1: u'AA', 2: u'aa'})
+        self.handler._escape_invalid_chars(openstring)
+        self.assertEqual(
+            openstring.string, {5: u'者\u0008・最', 1: u'\u0008AA', 2: u'\u0008aa'},
+        )


### PR DESCRIPTION
Escape special control characters and other non-printable characters.
Use Unicode escaped format as a replacement when compiling.
For example, the backspace control character gets escaped to \u0008.

See: https://yaml.org/spec/1.2/spec.html#id2770814 for the spec

Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
