### PR TITLE
Escape control characters on compile

### DIFF
--- a/openformats/strings.py
+++ b/openformats/strings.py
@@ -110,6 +110,10 @@ class OpenString(object):
         else:
             return self._strings[5]
 
+    @property
+    def strings(self):
+        return self._strings
+
     def _get_string_hash(self):
         keys = [self.key, self.context or '']
         return md5(':'.join(keys).encode('utf-8')).hexdigest()

--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -137,3 +137,14 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
         openstring = OpenString('k', u' @κάπου')
         string = self.handler._transform_yaml_string(openstring)
         self.assertEqual(string, u'" @κάπου"')
+
+    def test_escape_control_characters(self):
+        openstring = OpenString('k', u'者・最')  # 2nd character is the backspace char
+        self.handler._escape_invalid_chars(openstring)
+        self.assertEqual(openstring.string, u'者\\u0008・最')
+
+        openstring = OpenString('k', {5: u'者・最', 1: u'AA', 2: u'aa'})
+        self.handler._escape_invalid_chars(openstring)
+        self.assertEqual(
+            openstring.string, {5: u'者\\u0008・最', 1: u'\\u0008AA', 2: u'\\u0008aa'},
+        )


### PR DESCRIPTION
Problem and/or solution
-----------------------
Escape special control characters and other non-printable characters. Use Unicode escaped format as a replacement when compiling. For example, the backspace control character gets escaped to `\u0008`.

See: https://yaml.org/spec/1.2/spec.html#id2770814 for the spec

How to test
-----------
Unit tests.

Also:

(1) upload the following file to Transifex:
```
---
something:
  key: This is something

---
```
(2) Translate using `ab` as the translation text (there is a backspace char between `a` and `b`, so copy + paste from here)

(3) Download for use. The downloaded file should look like this
```
---
something:
  key: a\u0008b

---
```

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
