### PR TITLE
Unescape non-printable chars in markdown YAML headers

### DIFF
--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -3,6 +3,8 @@ import unittest
 from io import open
 from os import path
 
+import six
+
 from openformats.formats.github_markdown_v2 import GithubMarkdownHandlerV2
 from openformats.strings import OpenString
 from openformats.tests.formats.common import CommonFormatTestMixin
@@ -148,3 +150,24 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
         self.assertEqual(
             openstring.string, {5: u'者\\u0008・最', 1: u'\\u0008AA', 2: u'\\u0008aa'},
         )
+
+    def test_unescape_control_characters_escapes_non_printable(self):
+        openstring = OpenString(
+            'k', u'start\\x01\\x02\\x03\\u0003\\x04\\u0004\\x05\\x06\\x07\\x08'
+                 u'\\x10\\x11\\x12\\x1e\\x1F\\x7fend'
+        )
+        self.handler._unescape_non_printable(openstring)
+        expected = u'start\x01\x02\x03\x03\x04\x04\x05\x06\x07\x08' \
+                   u'\x10\x11\x12\x1e\x1F\x7fend'
+
+        self.assertEqual(
+            openstring.string,
+            expected,
+        )
+
+    def test_unescape_control_characters_keeps_printable(self):
+        openstring = OpenString(
+            'k', u'start\x85\x00\x09\xA9\\u0041end'
+        )
+        self.handler._unescape_non_printable(openstring)
+        self.assertEqual(openstring.string, u'start\x85\x00\x09\xA9\\u0041end')


### PR DESCRIPTION
Problem and/or solution
-----------------------
YAML defines a set of characters that are considered to be invalid. It accepts only printable characters: https://yaml.org/spec/1.2/spec.html#id2770814

Specifically, it says that:
> On input, a YAML processor must accept all Unicode characters except those explicitly excluded above.
> On output, a YAML processor must only produce acceptable characters. Any excluded characters must be presented using escape sequences. In addition, any allowed characters known to be non-printable should also be escaped.

The GithubMarkdown format has a YAML header, which must too conform to these specs. The latter was handled in #164. The former is handled by this PR. Note that both aspects are only handled for the YAML part of the GithubMarkdown format, not the YAML format. 

More specifically, when parsing the YAML header, any escaped non-printable character (i.e. a string with length > 1 in Python), such as `\x03` and `\u0004` is converted to the equivalent character (one-character string in Python).

How to test
-----------
1. Unit tests.

2. Use the following content on the testbed:
```yaml
---
test:
  should_be_escaped: \x01\x02\x03\x04\x05\x06\x07\x08\x10\x11\x12\x1e\x1F\x7f
  should_be_kept: \x85\x00\x09\xA9

---

A line is needed otherwise all strings in the YAML header are parsed as one (no clue why).

```
3. Upload a Github Markdown resource with the above content and see how it's parsed (look at the Editor).

#### NOTE
When compiling a characters with the `\xNN` format, the compiler cannot know that they were previously formatted like this and thus it converts them to the equivalent `\uNNNN` notation. For example, `\x08` will become `\u0008` when compiled.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
