### PR TITLE
Reimplementation of InDesign handler

### DIFF
--- a/openformats/formats/indesign.py
+++ b/openformats/formats/indesign.py
@@ -203,6 +203,13 @@ class InDesignHandler(Handler):
 
     @staticmethod
     def _make_zipfile_copy(zipfile_in, data):
+        """ Copy most of 'zipfile_in' to a new zip file. If a filename in
+            'zipfile_in' exists as a key in 'data', then instead of copying
+            that file from 'zipfile_in', write the relevant value from 'data'.
+
+            Return the byte contents of the new zipfile.
+        """
+
         file_out = io.BytesIO()
         zipfile_out = zipfile.ZipFile(file_out, 'w')
         for filename in zipfile_in.namelist():

--- a/openformats/formats/indesign.py
+++ b/openformats/formats/indesign.py
@@ -1,77 +1,158 @@
 from __future__ import absolute_import
 
 import io
+import re
+import unicodedata
 import zipfile
 from itertools import count
 
 import six
-
 from lxml import etree
+
 from openformats.handlers import Handler
 from openformats.strings import OpenString
 from openformats.transcribers import Transcriber
-from openformats.utils.xml import NewDumbXml as DumbXml
+from openformats.utils.compat import ensure_unicode
 
 
 class InDesignHandler(Handler):
+    """ A handler class that parses and compiles .idml files that are created
+        in Adobe's InDesign.
+
+        IDML files contain multiple XML fragments that can be parsed to extract
+        strings from.
+    """
+
     name = "InDesign"
     extension = "idml"
     SPECIFIER = None
     PROCESSES_BINARY = True
     EXTRACTS_RAW = False
 
+    # The ? at the end of the string regex, makes it non-greedy in order to
+    # allow trailing spaces to be preserved
+    CONTENT_REGEX = r'(<Content>\s*)(.*?)(\s*</Content>)'
+    SPECIAL_CHARACTERS_REGEX = re.compile(
+        ensure_unicode(r'<\?ACE \d+\?>|<Br/>;')
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.order_gen = count()
+        self.stringset = []
+
     def parse(self, content, **kwargs):
-        order_gen, stringset, template_dict = count(), [], {}
+        """ Parses .idml file content and returns the resource template and
+            stringset.
+            * Find all Story fragments based on the contents of 'designmap.xml'
+            * Parse all Story fragments to extract the translatable strings
+              and replace them with a replacement hash
+            * Copy the source archive into a new one, trying to preserve as
+              much of the structure and content as possible, but replacing the
+              story fragments with the templates
+            * Return the (template, stringset) tuple
+        """
+
+        template_dict = {}
         f_in = io.BytesIO(content)
         z_in = zipfile.ZipFile(f_in)
         filenames = self._get_story_filenames(z_in)
 
         for filename in filenames:
             story = z_in.read(filename).decode('utf-8')
-            transcriber = Transcriber(story)
-            story = transcriber.source
-            root = DumbXml(story, story.index('<idPkg:Story'))
-            for content in root.find_descendants('Content'):
-                if content.content is None or not content.content.strip():
-                    continue
-                order = next(order_gen)
-                string = OpenString(six.text_type(order), content.content,
-                                    order=order)
-                transcriber.copy_until(content.text_position)
-                transcriber.add(string.template_replacement)
-                transcriber.skip(len(content.content))
-                stringset.append(string)
-            transcriber.copy_to_end()
-            template_dict[filename] = transcriber.get_destination()
+            template_dict[filename] = self._find_and_replace(story)
 
         f_out = io.BytesIO()
         z_out = zipfile.ZipFile(f_out, 'w')
         for filename in z_in.namelist():
             z_out.writestr(z_in.getinfo(filename),
                            template_dict.get(filename, z_in.read(filename)))
+        z_out.close()
         f_out.seek(0)
-        return f_out.read(), stringset
+        return f_out.read(), self.stringset
+
+    def _find_and_replace(self, story_xml):
+        """ Finds all the translatable content in the given XML string
+            replaces it with the string_hash and returns the resulting
+            template while updating `self.stringset` in the process.
+            args:
+                story_xml (str): The xml content of a single Story of the IDML
+                file
+            returns:
+                the input string with all translatable content replaced by the
+                md5 hash of the string.
+        """
+        template = re.sub(ensure_unicode(self.CONTENT_REGEX),
+                          self._replace,
+                          story_xml)
+        return template
+
+    def _replace(self, match):
+        """ Implements the logic used by `self.CONTENT_REGEX.sub(...)` to
+            replace strings with their template replacement and appends new
+            strings to `self.stringset`.
+        """
+        opening_tag, string, closing_tag = match.groups()
+
+        if self._can_skip_content(string):
+            return match.group()
+        order = next(self.order_gen)
+        string_object = OpenString(six.text_type(order), string, order=order)
+        self.stringset.append(string_object)
+        return u"".join((opening_tag, string_object.template_replacement,
+                         closing_tag))
+
+    def _can_skip_content(self, string):
+        """ Checks if the contents of an XML files are translateable.
+            Strings that contain only special characters or can be evaluated
+            to a nunber are skipped.
+        """
+        stripped_string = re.\
+            sub(ensure_unicode(self.SPECIAL_CHARACTERS_REGEX), u'', string).\
+            strip()
+        if not stripped_string:
+            return True
+        try:
+            float(string.strip())
+            return True
+        except ValueError:
+            pass
+        if not self._contains_translatable_character(stripped_string):
+            return True
+        return False
+
+    def _contains_translatable_character(self, string):
+        """ Checks if a string contains at least one character that can be
+            translated. We assume that translatable characters are the letters,
+            the symbols and the punctuation.
+        """
+
+        for letter in string:
+            char_type = unicodedata.category(letter)
+            if char_type[0] in ("L", "P", "S"):
+                return True
+        return False
 
     def compile(self, template, stringset, **kwargs):
-        stringset, compiled_dict = iter(stringset), {}
-        string = next(stringset)
+        """ Compiles .idml template against the stringset and returns the
+            compiled file.
+            * Find all Story fragments based on the contents of 'designmap.xml'
+            * Find hashes from the stringset within the Story fragments and
+              replace them with the translations
+            * Replace hashes that weren't found with empty strings
+            * Copy the template archive into a new one, trying to preserve as
+              much of the structure and content as possible, but replacing the
+              story fragments with the compiled ones
+            * Return the compiled archive
+        """
+
+        self.stringset, compiled_dict = iter(stringset), {}
+        self.string = next(self.stringset)
         f_in = io.BytesIO(template)
         z_in = zipfile.ZipFile(f_in)
         filenames = self._get_story_filenames(z_in)
         for filename in filenames:
             template = z_in.read(filename).decode('utf8')
-            transcriber = Transcriber(template)
-            template = transcriber.source
-            root = DumbXml(template, template.index('<idPkg:Story'))
-            for content in root.find_descendants('Content'):
-                if content.content != string.template_replacement:
-                    continue
-                transcriber.copy_until(content.text_position)
-                transcriber.add(string.string)
-                transcriber.skip(len(content.content))
-                string = next(string, None)
-            transcriber.copy_to_end()
-            compiled_dict[filename] = transcriber.get_destination()
+            compiled_dict[filename] = self._compile_story(template)
 
         f_out = io.BytesIO()
         z_out = zipfile.ZipFile(f_out, 'w')
@@ -81,11 +162,47 @@ class InDesignHandler(Handler):
                 z_out.writestr(info, compiled_dict[filename].encode('utf8'))
             else:
                 z_out.writestr(info, z_in.read(filename))
+        z_out.close()
         f_out.seek(0)
         return f_out.read()
 
+    def _compile_story(self, template):
+        """ Handles the compilation of a single story
+            args:
+                story_content: the xml content of the story
+            returns:
+                compiled_story: the compiled story content
+        """
+
+        transcriber = Transcriber(template)
+        template = transcriber.source
+        hash_regex = re.compile(ensure_unicode(r'[a-z,0-9]{32}_tr'))
+        while self.string is not None:
+            try:
+                hash_position = template.index(
+                    self.string.template_replacement
+                )
+            except (ValueError, IndexError):
+                break
+            else:
+                transcriber.copy_until(hash_position)
+                transcriber.add(self.string.string)
+                transcriber.skip(len(self.string.template_replacement))
+                self.string = next(self.stringset, None)
+
+        transcriber.copy_to_end()
+        compiled = transcriber.get_destination()
+        compiled = hash_regex.sub(u'', compiled)
+        return compiled
+
     @staticmethod
     def _get_story_filenames(z_in):
+        """ Find the filenames of all Story fragmens by intersecting the list
+            of keys of the 'StoryList' attribute of the top node in
+            'designmap.xml' with the filenames within the archive that refer to
+            Story fragments.
+        """
+
         designmap = etree.fromstring(
             z_in.read('designmap.xml'),
             parser=etree.XMLParser(resolve_entities=False),

--- a/openformats/formats/indesign.py
+++ b/openformats/formats/indesign.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import io
-import re
-import unicodedata
+import zipfile
 from itertools import count
 
 import six
@@ -11,214 +10,86 @@ from lxml import etree
 from openformats.handlers import Handler
 from openformats.strings import OpenString
 from openformats.transcribers import Transcriber
-from openformats.utils.compat import ensure_unicode
-from ucf import UCF
+from openformats.utils.xml import NewDumbXml as DumbXml
 
 
 class InDesignHandler(Handler):
-    """A handler class that parses and compiles .idml files that are created
-    in Adobe's InDesign.
-
-    IDML files contain multiple XML fragments that can be parsed to extract
-    strings from.
-    """
-
     name = "InDesign"
     extension = "idml"
     SPECIFIER = None
     PROCESSES_BINARY = True
     EXTRACTS_RAW = False
 
-    # The ? at the end of the string regex, makes it non-greedy in order to
-    # allow trailing spaces to be preserved
-    CONTENT_REGEX = r'(<Content>\s*)(.*?)(\s*</Content>)'
-    SPECIAL_CHARACTERS_REGEX = re.compile(
-        ensure_unicode(r'<\?ACE \d+\?>|<Br/>;')
-    )
-
-    """ Parse Methods """
-
-    def __init__(self, *args, **kwargs):
-        self.order = count()
-        self.stringset = []
-        super(InDesignHandler, self).__init__(*args, **kwargs)
-
     def parse(self, content, **kwargs):
-        """ Parses .idml file content and returns the resource template and
-            stringset.
-            * Use UCF to unpack `content` to xml fragments
-            * Parse all Story fragments to extract the translatable strings
-              and replace them with a replacement hash
-            * Pack the fragments back to create the template
-            * Return the (template, stringset) tuple
-        """
+        order_gen, stringset, template_dict = count(), [], {}
+        f_in = io.BytesIO(content)
+        z_in = zipfile.ZipFile(f_in)
+        filenames = self._get_story_filenames(z_in)
 
-        idml = UCF(io.BytesIO(content))
-        ordered_stories = self._get_ordered_stories(idml)
+        for filename in filenames:
+            story = z_in.read(filename).decode('utf-8')
+            transcriber = Transcriber(story)
+            story = transcriber.source
+            root = DumbXml(story, story.index('<idPkg:Story'))
+            for content in root.find_descendants('Content'):
+                if content.content is None or not content.content.strip():
+                    continue
+                order = next(order_gen)
+                string = OpenString(six.text_type(order), content.content,
+                                    order=order)
+                transcriber.copy_until(content.text_position)
+                transcriber.add(string.template_replacement)
+                transcriber.skip(len(content.content))
+                stringset.append(string)
+            transcriber.copy_to_end()
+            template_dict[filename] = transcriber.get_destination()
 
-        # Iterate over the contents of the IDML file
-        for key in ordered_stories:
-            try:
-                # No matter what, idml values are bytes
-                story_content = idml[key].decode('utf8')
-            except KeyError:
-                continue
-            story_content = self._find_and_replace(story_content)
-
-            # Update the XML file to contain the template strings
-            idml[key] = story_content.encode('utf-8')
-
-        out = io.BytesIO()
-        idml.save(out)
-        template = out.getvalue()
-
-        return template, self.stringset
-
-    def _get_ordered_stories(self, idml):
-        """
-        Try to find the order the stories appear in the indesign document
-        * Parse designmap.xml to get the StoryList attribute.
-        * Return a list with the idml keys of the stories in the order they
-          appear in StoryList
-        """
-
-        STORY_KEY = 'Stories/Story_{}.xml'
-        BACKING_STORY = 'XML/BackingStory.xml'
-
-        designmap = idml.get('designmap.xml')
-        parser = etree.XMLParser(resolve_entities=False)
-        designmap_tree = etree.fromstring(designmap, parser=parser)
-
-        story_ids = designmap_tree.attrib.get("StoryList", "").split()
-        story_keys = [STORY_KEY.format(s) for s in story_ids]
-
-        # In case there are stories that is not referenced in designmap.xml,
-        # append them at the end of the list
-        all_stories = {
-            k for k in six.iterkeys(idml)
-            if k.startswith('Stories') or k == BACKING_STORY
-        }
-        story_keys.extend(all_stories - set(story_keys))
-        return story_keys
-
-    def _can_skip_content(self, string):
-        """
-        Checks if the contents of an XML files are translateable.
-        Strings that contain only special characters or can be evaluated
-        to a nunber are skipped.
-        """
-        stripped_string = re.\
-            sub(ensure_unicode(self.SPECIAL_CHARACTERS_REGEX), u'', string).\
-            strip()
-        if not stripped_string:
-            return True
-        try:
-            float(string.strip())
-            return True
-        except ValueError:
-            pass
-        if not self._contains_translatable_character(stripped_string):
-            return True
-        return False
-
-    def _contains_translatable_character(self, string):
-        """
-        Checks if a string contains at least one character that can be
-        translated. We assume that translatable characters are the letters,
-        the symbols and the punctuation.
-        """
-        acceptable = ["L", "P", "S"]
-
-        for letter in string:
-            char_type = unicodedata.category(letter)
-            if char_type[0] in acceptable:
-                return True
-        return False
-
-    def _find_and_replace(self, story_xml):
-        """
-        Finds all the translatable content in the given XML string
-        replaces it with the string_hash and returns the resulting
-        template while updating `self.stringset` in the process.
-        args:
-            story_xml (str): The xml content of a single Story of the IDML file
-        returns:
-            the input string with all translatable content replaced by the
-            md5 hash of the string.
-        """
-        template = re.sub(ensure_unicode(self.CONTENT_REGEX),
-                          self._replace,
-                          story_xml)
-        return template
-
-    def _replace(self, match):
-        """ Implements the logic used by `self.CONTENT_REGEX.sub(...)` to
-        replace strings with their template replacement and appends new strings
-        to `self.stringset`.
-        """
-        opening_tag, string, closing_tag = match.groups()
-
-        if self._can_skip_content(string):
-            return match.group()
-        order = next(self.order)
-        string_object = OpenString(six.text_type(order), string, order=order)
-        self.stringset.append(string_object)
-        return u"".join((opening_tag, string_object.template_replacement,
-                         closing_tag))
-
-    """ Compile Methods """
+        f_out = io.BytesIO()
+        z_out = zipfile.ZipFile(f_out, 'w')
+        for filename in z_in.namelist():
+            z_out.writestr(z_in.getinfo(filename),
+                           template_dict.get(filename, z_in.read(filename)))
+        f_out.seek(0)
+        return f_out.read(), stringset
 
     def compile(self, template, stringset, **kwargs):
-        # The content is a binary IDML file
-        idml = UCF(io.BytesIO(template))
+        stringset, compiled_dict = iter(stringset), {}
+        string = next(stringset)
+        f_in = io.BytesIO(template)
+        z_in = zipfile.ZipFile(f_in)
+        filenames = self._get_story_filenames(z_in)
+        for filename in filenames:
+            template = z_in.read(filename).decode('utf8')
+            transcriber = Transcriber(template)
+            template = transcriber.source
+            root = DumbXml(template, template.index('<idPkg:Story'))
+            for content in root.find_descendants('Content'):
+                if content.content != string.template_replacement:
+                    continue
+                transcriber.copy_until(content.text_position)
+                transcriber.add(string.string)
+                transcriber.skip(len(content.content))
+                string = next(string, None)
+            transcriber.copy_to_end()
+            compiled_dict[filename] = transcriber.get_destination()
 
-        self.stringset = list(stringset)
-
-        # Iterate over the contents of the IDML file
-        for key in self._get_ordered_stories(idml):
-            try:
-                story_content = idml[key]
-            except KeyError:
-                continue
-
-            # no matter what, idml values are bytes
-            story_content = idml[key].decode('utf-8')
-            idml[key] = self._compile_story(story_content).encode('utf-8')
-
-        out = io.BytesIO()
-        idml.save(out)
-        return out.getvalue()
-
-    def _compile_story(self, story_content):
-        """ Handles the compilation of a single story
-        args:
-            story_content: the xml content of the story
-        returns:
-            compiled_story: the compiled story content
-        """
-        transcriber = Transcriber(story_content)
-        hash_regex = re.compile(ensure_unicode(r'[a-z,0-9]{32}_tr'))
-        found = True
-        while found:
-            try:
-                current_string = self.stringset.pop(0)
-                hash_position = story_content.index(
-                    current_string.template_replacement
-                )
-            except ValueError:
-                found = False
-                self.stringset.insert(0, current_string)
-            except IndexError:
-                break
+        f_out = io.BytesIO()
+        z_out = zipfile.ZipFile(f_out, 'w')
+        for filename in z_in.namelist():
+            info = z_in.getinfo(filename)
+            if filename in compiled_dict:
+                z_out.writestr(info, compiled_dict[filename].encode('utf8'))
             else:
-                transcriber.copy_until(hash_position)
-                transcriber.add(current_string.string)
-                transcriber.skip(len(current_string.template_replacement))
+                z_out.writestr(info, z_in.read(filename))
+        f_out.seek(0)
+        return f_out.read()
 
-        # Update the XML file to contain the template strings
-        transcriber.copy_until(len(story_content))
-        compiled_story = transcriber.get_destination()
-        # in case there are any hashes that have not been replaced, replace
-        # them with an empty string
-        compiled_story = hash_regex.sub(u'', compiled_story)
-        return compiled_story
+    @staticmethod
+    def _get_story_filenames(z_in):
+        designmap = etree.fromstring(
+            z_in.read('designmap.xml'),
+            parser=etree.XMLParser(resolve_entities=False),
+        )
+        story_keys = {'Stories/Story_{}.xml'.format(key)
+                      for key in designmap.attrib.get('StoryList', "").split()}
+        return sorted(story_keys & set(z_in.namelist()))

--- a/openformats/tests/formats/indesign/test_indesign.py
+++ b/openformats/tests/formats/indesign/test_indesign.py
@@ -115,10 +115,9 @@ class InDesignTestCase(unittest.TestCase):
             </Story>
         """
         handler = self.HANDLER_CLASS()
-        handler.stringset = [
-            OpenString(u"0", u"Some string 1", order=0),
-            OpenString(u"1", u"Some string 2", order=1),
-        ]
+        handler.stringset = iter([OpenString(u"0", u"Some string 1", order=0),
+                                  OpenString(u"1", u"Some string 2", order=1)])
+        handler.string = next(handler.stringset)
 
         compiled_story = handler._compile_story(simple_story_template)
         self.assertEqual(compiled_story, simple_compiled_story)
@@ -141,9 +140,8 @@ class InDesignTestCase(unittest.TestCase):
             </Story>
         """
         handler = self.HANDLER_CLASS()
-        handler.stringset = [
-            OpenString(u"0", u"Some string 1", order=0),
-        ]
+        handler.stringset = iter([OpenString(u"0", u"Some string 1", order=0)])
+        handler.string = next(handler.stringset)
 
         compiled_story = handler._compile_story(simple_story_template)
         self.assertEqual(compiled_story, simple_compiled_story)
@@ -183,16 +181,12 @@ class InDesignTestCase(unittest.TestCase):
         """
         # strings #1 and #2 are missing from the stringset
         handler = self.HANDLER_CLASS()
-        handler.stringset = [
-            OpenString(u"0", u"Some string 1", order=0),
-            OpenString(u"3", u"Some string 2", order=3),
-        ]
+        handler.stringset = [OpenString(u"0", u"Some string 1", order=0),
+                             OpenString(u"3", u"Some string 2", order=3)]
+        handler.stringset = iter(handler.stringset)
+        handler.string = next(handler.stringset)
 
-        first_compiled_story = handler._compile_story(
-            first_story_template
-        )
-        second_compiled_story = handler._compile_story(
-            second_story_template
-        )
+        first_compiled_story = handler._compile_story(first_story_template)
+        second_compiled_story = handler._compile_story(second_story_template)
         self.assertEqual(first_compiled_story, expected_first_compiled_story)
         self.assertEqual(second_compiled_story, expected_second_compiled_story)

--- a/openformats/utils/xml.py
+++ b/openformats/utils/xml.py
@@ -354,6 +354,7 @@ class NewDumbXml(object):
         "Special value for None because for some properties, None is valid"
 
     COMMENT = '!--'
+    PROCESSING_INSTRUCTION = '?'
 
     def __init__(self, source, start=0):
         self.source = source
@@ -397,6 +398,12 @@ class NewDumbXml(object):
         if self.source[start:end] == "<!--":
             self._tag = self.COMMENT
             self._process_comment()
+            return self._tag
+
+        end = start + len('<?')
+        if self.source[start:end] == "<?":
+            self._tag = self.PROCESSING_INSTRUCTION
+            self._process_processing_instruction()
             return self._tag
 
         for ptr in six.moves.xrange(self.position + 1, len(self.source)):
@@ -552,7 +559,8 @@ class NewDumbXml(object):
         return self._text
 
     def __iter__(self):
-        if self.text is None or self.tag == self.COMMENT:
+        if (self.text is None or self.tag == self.COMMENT
+                or self.tag == self.PROCESSING_INSTRUCTION):
             return
 
         start = self.text_position + len(self.text)
@@ -615,7 +623,7 @@ class NewDumbXml(object):
                ^^^^^^^^^^^^^^^^^^^^^^^^^
         """
 
-        if self.tag == self.COMMENT:
+        if self.tag == self.COMMENT or self.tag == self.PROCESSING_INSTRUCTION:
             return self.text
         if self.content_end is None:
             return None
@@ -714,6 +722,22 @@ class NewDumbXml(object):
                 return
         raise DumbXmlSyntaxError(u"Comment not closed on line {}".
                                  format(self._find_line_number()))
+
+    def _process_processing_instruction(self):
+        self._attrib_string, self._attributes, self._attrib = "", [], {}
+
+        self._text_position = self.position + len("<?")
+        for ptr in six.moves.xrange(self._text_position, len(self.source)):
+            candidate = self.source[ptr]
+            if candidate == "?" and self.source[ptr:ptr + len("?>")] == "?>":
+                self._content_end = ptr
+                self._text = self.source[self.text_position:ptr]
+                self._tail_position = ptr + len("?>")
+                return
+        raise DumbXmlSyntaxError(
+            u"Processing instruction not closed on line {}".
+            format(self._find_line_number())
+        )
 
     def _find_line_number(self, ptr=None):
         ptr = ptr or self.position

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ six
 
 # InDesign
 lxml==4.1.1
-git+git://github.com/kbairak/ucflib@py3_compatibility


### PR DESCRIPTION
Problem and/or solution
-----------------------

It turns out that using UCFLib can damage the idml archive. The
indications we have of this is that files compiled by this handler:

1. Show up as "corrupted" in InDesign
2. Have messed up permissions when extracted by archive managers (tested
   on Linux and MacOS operating systems)

The new implementation operates on the archives directly. We access
'designmap.xml' to gather the story IDs, then gather all the story files
and extract the content their <Content> tags as templates. Finally we
create a new archive identical in every way possible to the old one but
with the stories replaced by the templates. A very similar process is
performed during compilation.

It turns out that trying to retain as much of the structure and content
of the resulting archive fixes our issues.

How to test
-----------

Theoretically, the output of parsing and compiling, at least in terms of
strings and individual story templates, should be the same as before,
thus the same tests should pass.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
