### PR TITLE
Escape `&` when compiling IDML (InDesign) files

### DIFF
--- a/openformats/tests/formats/indesign/test_indesign.py
+++ b/openformats/tests/formats/indesign/test_indesign.py
@@ -196,3 +196,36 @@ class InDesignTestCase(unittest.TestCase):
         )
         self.assertEqual(first_compiled_story, expected_first_compiled_story)
         self.assertEqual(second_compiled_story, expected_second_compiled_story)
+
+    def test_compile_story_with_amps(self):
+        regular = OpenString('0', u"hello world", order=0)
+        with_amp = OpenString('1', u"hello &world", order=1)
+        with_amp_escaped = OpenString('2', u"hello &lt;world", order=2)
+        many_amps = OpenString('3', u"&&#x0a1f;&&", order=3)
+
+        base_template = u"""
+            <Story>
+                <Content>{regular}</Content>
+                <Content>{with_amp}</Content>
+                <Content>{with_amp_escaped}</Content>
+                <Content>{many_amps}</Content>
+            </Story>
+        """
+
+        template = base_template.format(
+            regular=regular.template_replacement,
+            with_amp=with_amp.template_replacement,
+            with_amp_escaped=with_amp_escaped.template_replacement,
+            many_amps=many_amps.template_replacement,
+        )
+        expected_compiled_story = base_template.format(
+            regular=u"hello world",
+            with_amp=u"hello &amp;world",
+            with_amp_escaped=u"hello &lt;world",
+            many_amps=u"&amp;&#x0a1f;&amp;&amp;",
+        )
+
+        handler = self.HANDLER_CLASS()
+        handler.stringset = [regular, with_amp, with_amp_escaped, many_amps]
+        compiled_story = handler._compile_story(template)
+        self.assertEqual(compiled_story, expected_compiled_story)


### PR DESCRIPTION
Problem and/or solution
-----------------------

"Lonely" ampersands (`&`) will make the resulting XML story fragments
invalid and subsequently InDesign will not be able to import the file
and it will appear corrupt. This commit forces the escaping of lonely
`&` to the proper XML escape sequence: `&amp;`.

If, however, a valid escape sequence appears in the string (eg `&lt;` or
`&#x0a1f;`), we will assume that the translator knew what they were
doing and we will not escape the sequence's first character.

So, for example, the following escapes will occur:

    "hello world"         -> "hello world"
    "hello &world"        -> "hello &amp;world"
    "hello &amp;world"    -> "hello &amp;world"
    "hello &lt;world"     -> "hello &lt;world"
    "hello &#x0a1f;world" -> "hello &#x0a1f;world"
    "&&#x05af;&&"         -> "&amp;&#x05af;&amp;&amp;"

How to test
-----------

It is a bit hard to test without having InDesign installed, but if you read and run the new unit-test you should be comfortable with the result.

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
