### PR TITLE
Fix markdown code block issue

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -37,13 +37,13 @@ def string_handler(token, template):
         lines = string.split('\n')
         line = lines[0]
         spaces = re.findall(
-            ensure_unicode(r'\n( *){}'.format(re.escape(line))),
+            ensure_unicode(r'\n( *){}').format(re.escape(line)),
             template
         )[0]
         if spaces:
             string = ''
             for line in lines:
-                line = '{}{}'.format(spaces, line)
+                line = u'{}{}'.format(spaces, line)
                 string += '\n'
                 string += line
 


### PR DESCRIPTION
Problem and/or solution
-----------------------
There is an issue in parsing code blocks in markdown files. Right now we
don't handle the content of a code block as unicode and raises and
error.

How to test
-----------
Use this in testbed:
```
1. Test string.

        óαά
```
and/or the resource in the ticket.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
