### PR TITLE
Fix missing quotes in GithubMarkdownHandlerV2

### DIFF
--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -229,7 +229,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         :return: a string that is valid for exporting
         :rtype: str
         """
-        should_wrap, quote_char = self._should_wrap_in_quotes(openstring.string)
+        should_wrap, quote_char = self._should_wrap_in_quotes(openstring)
         if should_wrap:
             string = self._wrap_in_quotes(openstring.string, quote_char)
         else:
@@ -268,7 +268,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         # wrap string with quotes
         return '{}{}{}'.format(quote_char, string, quote_char)
 
-    def _should_wrap_in_quotes(self, string):
+    def _should_wrap_in_quotes(self, openstring):
         """Check if the given string should be wrapped in quotes.
 
         In order to decide if wrapping is necessary, it takes into account
@@ -280,7 +280,11 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
             the character that should be used for wrapping
         :rtype: tuple (bool, str)
         """
-        string = string.strip()
+        # If single or double quote flags appear, wrap it.
+        if openstring.flags in [self.DOUBLE_QUOTES, self.SINGLE_QUOTE]:
+            return True, openstring.flags
+
+        string = openstring.string.strip()
 
         # If wrapped already in double quotes, don't wrap again
         wrapped_in_double_quotes = (

--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -54,25 +54,30 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
         self.assertTrue(self.handler._is_yaml_string(openstring))
 
     def test_should_wrap_in_quotes_false_if_no_special_case(self):
-        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(u' Απλό case')
+        openstring = OpenString('k', u' Απλό case')
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(openstring)
         self.assertFalse(should_wrap)
         self.assertIsNone(wrap_char)
 
     def test_should_wrap_in_quotes_false_if_already_wrapped(self):
-        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(u'  "Κάτι άλλο "')
+        openstring = OpenString('k', u'  "Κάτι άλλο "')
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(openstring)
         self.assertFalse(should_wrap)
         self.assertIsNone(wrap_char)
 
-        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(u"  'Κάτι άλλο' ")
+        openstring = OpenString('k', u"  'Κάτι άλλο' ")
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(openstring)
         self.assertFalse(should_wrap)
         self.assertIsNone(wrap_char)
 
     def test_should_wrap_in_quotes_if_starts_but_not_ends_with_quote(self):
-        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(u' " Κάτι άλλο ')
+        openstring = OpenString('k', u' " Κάτι άλλο ')
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(openstring)
         self.assertTrue(should_wrap)
         self.assertEqual(wrap_char, u"'")
 
-        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(u" ' Κάτι άλλο  ")
+        openstring = OpenString('k', u" ' Κάτι άλλο  ")
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(openstring)
         self.assertTrue(should_wrap)
         self.assertEqual(wrap_char, u'"')
 
@@ -84,8 +89,9 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
             GithubMarkdownHandlerV2.AT_SIGN,
         ]
         for char in starting_chars:
+            openstring = OpenString('k', u' {} Κάτι άλλο '.format(char))
             should_wrap, wrap_char = self.handler._should_wrap_in_quotes(
-                u' {} Κάτι άλλο '.format(char)
+                openstring
             )
             self.assertTrue(should_wrap)
             self.assertEqual(wrap_char, u'"')
@@ -97,14 +103,16 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
             GithubMarkdownHandlerV2.HASHTAG,
         ]
         for char in special_chars:
+            openstring = OpenString('k', u' Κάτι άλλο {} -'.format(char))
             should_wrap, wrap_char = self.handler._should_wrap_in_quotes(
-                u' Κάτι άλλο {} -'.format(char)
+                openstring
             )
             self.assertTrue(should_wrap)
             self.assertEqual(wrap_char, u'"')
 
     def test_should_wrap_in_quotes_if_starts_but_not_ends_with_bracket(self):
-        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(u' [Κάτι] άλλο ')
+        openstring = OpenString('k', u' [Κάτι] άλλο ')
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(openstring)
         self.assertTrue(should_wrap)
         self.assertEqual(wrap_char, u'"')
 
@@ -127,6 +135,16 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
 
     def test_transform_yaml_string_wrapped_for_brackets(self):
         openstring = OpenString('k', u' [Θέλω] quotes')
+        string = self.handler._transform_yaml_string(openstring)
+        self.assertEqual(string, u'" [Θέλω] quotes"')
+
+    def test_transform_yaml_string_wrapped__with_flag_single_quotes(self):
+        openstring = OpenString('k', u' [Θέλω] quotes', flags=u"'")
+        string = self.handler._transform_yaml_string(openstring)
+        self.assertEqual(string, u"' [Θέλω] quotes'")
+
+    def test_transform_yaml_string_wrapped_with_flag_double_quotes(self):
+        openstring = OpenString('k', u' [Θέλω] quotes', flags=u'"')
         string = self.handler._transform_yaml_string(openstring)
         self.assertEqual(string, u'" [Θέλω] quotes"')
 


### PR DESCRIPTION
Problem 
---------
YAML Header does not take into account openstrings with single or double quotes on their corresponding `openstrings.flags` field.

Solution
--------
We Change the `_should_wrap_in_quotes` method to also wrap in single or
double quotes the YAML openstring regarding the flag.

How to test
-----------

- `./manage.py test openformats.tests.formats.github_markdown_v2.test_github_markdown`

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
