### PR TITLE
Escape dotted keys properly in `STRUCTURED_JSON`

### DIFF
--- a/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
@@ -40,6 +40,24 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
                          self.random_openstring.__dict__)
         self.assertEqual(compiled,
                          '{"a": {"string":"%s"}}' % self.random_string)
+    
+    def test_dots_in_key(self):
+        first_level_key = "a.b"
+        source = '{"%s": {"c": {"string": "%s"}}}' % (first_level_key, self.random_string)
+        openstring = OpenString(
+            "{}.c".format(self.handler._escape_key(first_level_key)), 
+            self.random_string, order=0
+        )
+        random_hash = openstring.template_replacement
+
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [openstring])
+
+        self.assertEqual(template,
+                         '{"a.b": {"c": {"string": "%s"}}}' % random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__, openstring.__dict__)
+        self.assertEqual(compiled, source)
 
     def test_embedded_dicts(self):
         source = '{"a": {"b": {"string": "%s"}}}' % self.random_string


### PR DESCRIPTION
Problem and/or solution
-----------------------

### Problem
In the case of `STRUCTURED_JSON` handler we need to differentiate between translatable content and structure (context, developer comments, ...). In order to get this structure and give it as input to the `OpenString` class, we parse the input dictionary and try to find the value for each key (function `_get_string_structure()`). Since the key has the form `first.nest_1.nest_2.sting` for the translatable part and `first.nest_1.nest_2.context` for the context that is for example one part of the structure, we split the keys on the dot and get the values for the structure fields. Thus, if a key has a dot that does not denote nesting e.g `fir\.st.nest_1.nest_2.string`, we end up looking for a key that does not exist (`fir\`). However, our dictionary will have the form:
```
{
    u'fir.st': {
        u'nest_1': {
            u'nest_2' : {
                u'developer_comment': u'dev comment', 
                u'string': u'Ignore', 
                u'context': u'Additional context'
            }
        }
    }
} 
``` 
and thus we are not able to get the correct structure.

### Solution
Split the key using `csv.reader` with `escapechar="\\"`. This way, we avoid splitting on the escaped dot in the key `fir\.st.nest_1.nest_2.string`, thus end up with keys `fir.st`, `nest_1`, `nest_2` and `string` that are indeed part of our dictionary in a nested form.

How to test
-----------
```
openformats.tests.formats.structuredkeyvaluejson.test_keyvaluejson.test_dots_in_key
```

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
