### PR TITLE
Expose structured parsing result for PO files

### DIFF
--- a/openformats/formats/po.py
+++ b/openformats/formats/po.py
@@ -46,10 +46,10 @@ class PoHandler(Handler):
             if openstring is not None:
                 stringset.append(openstring)
 
-        po_str = self._po_file_to_str(self.new_po)
-        return po_str, stringset
+        return self.new_po, stringset
 
-    def _po_file_to_str(self, po_file):
+    @staticmethod
+    def pofile_to_str(po_file):
         """
         Generate the template for the PO file.
 
@@ -300,7 +300,11 @@ class PoHandler(Handler):
         stringset = iter(stringset)
         next_string = next(stringset, None)
 
-        po = polib.pofile(template)
+        if isinstance(template, polib.POFile):
+            po = template
+        else:
+            po = polib.pofile(template)
+
         indexes_to_remove = []
         for i, entry in enumerate(po):
             if next_string is not None:
@@ -314,7 +318,8 @@ class PoHandler(Handler):
                     continue
             indexes_to_remove.append(i)
         self._smart_remove(po, indexes_to_remove)
-        return self._po_file_to_str(po)
+
+        return PoHandler.pofile_to_str(po)
 
     def _compile_entry(self, entry, next_string):
         """Compiles the current non pluralized entry.

--- a/testbed/main/views.py
+++ b/testbed/main/views.py
@@ -111,6 +111,8 @@ class ApiView(HandlerMixin, View):
                             'compile_error': ""}
         try:
             template, stringset = handler.parse(source)
+            if handler.name == 'PO':
+                template = handler.pofile_to_str(template)
         except Exception:
             returned_payload.update({'stringset': [], 'template': "",
                                      'parse_error': traceback.format_exc()})


### PR DESCRIPTION
Problem and/or solution
-----------------------

When compiling the same file in different languages,
only the supplied stringset changes for every language
and the template remains the same.

The PoHandler for every compilation, re-parses the template
and applies the changes on top of the generated parsing result.
With this change we allow clients to reuse the parsing result
when compiling and optimize the performance by skipping the
template parsing.

Note: This change is backwards incompatible regarding the
return type of the `parse` method. The template string can be
retrieved by calling `pofile_to_str` on top of the generated
structure po.

How to test
-----------
The combination of parse/compile remains unchanged as long as the client is not interested in the format of the template.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
