### PR TITLE
Throw ParseError on duplicate YAML keys

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -95,6 +95,8 @@ class TxYamlLoader(yaml.SafeLoader):
         Override `yaml.SafeLoader.construct_mapping` to return for each item
         of the mapping a tuple of the form `(key, (value, start, end, style,
         tag))` instead of the default which is `(key, value)`.
+        :raise ParseError: if node is not a MappingNode
+            or duplicate keys are found.
         """
         if not isinstance(node, yaml.MappingNode):
             raise ParseError(
@@ -161,6 +163,26 @@ class TxYamlLoader(yaml.SafeLoader):
 
             value = Node(value, start, end, style, tag)
             pairs.append((key, value))
+
+        # If there are duplicate keys, throw an exception
+        pair_keys = [pair[0] for pair in pairs]
+        seen = set()
+        duplicates = set()
+        seen_add = seen.add
+        duplicate_add = duplicates.add
+        for x in pair_keys:
+            if x not in seen:
+                seen_add(x)
+            else:
+                duplicates_add(x)
+
+        if len(duplicates):
+            duplicates_list = list(duplicates)
+            error_duplicate_keys = ','.join(key for key in duplicates_list)
+            raise ParseError(
+                "Duplicate keys found ({})".format(error_duplicate_keys)
+            )
+
         return pairs
 
     def construct_sequence(self, node, deep=True):

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -146,3 +146,16 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
         content_string = strings[1]
         self.assertEqual(content_string.context, '!tag')
         self.assertEqual(content_string.flags, "'")
+
+    def test_parse_duplicate_keys(self):
+        content = '''\
+            something:
+              attribute_1: Attribute 1 value
+              attribute_2: Attribute 2 value
+              attribute_3: Attribute 3 value
+              attribute_1: Attribute 1 value
+              attribute_2: Attribute 2 value
+        '''
+
+        with self.assertRaises(ParseError):
+            self.handler.parse(content)


### PR DESCRIPTION
Problem
------------
Duplicate keys are not allowed, according to the YAML specification. Under the hood, we use the PYYAML library. For the time being, PYYAML parser accepts duplicate yaml keys and this is an issue that [has been reported by the Open Source Community](https://github.com/yaml/pyyaml/issues/165).

Solution
-----------
We post process the generated pairs to verify that we do not have duplicate keys.

How to test
-----------
Run `python setup.py test`. A new test `test_parse_duplicate_keys (openformats.tests.formats.yaml.test_yaml.YamlTestCase)` has been added.
 
Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
