### PR TITLE
openformats update (0.0.67)

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -95,6 +95,8 @@ class TxYamlLoader(yaml.SafeLoader):
         Override `yaml.SafeLoader.construct_mapping` to return for each item
         of the mapping a tuple of the form `(key, (value, start, end, style,
         tag))` instead of the default which is `(key, value)`.
+        :raise ParseError: if node is not a MappingNode
+            or duplicate keys are found.
         """
         if not isinstance(node, yaml.MappingNode):
             raise ParseError(
@@ -161,6 +163,26 @@ class TxYamlLoader(yaml.SafeLoader):
 
             value = Node(value, start, end, style, tag)
             pairs.append((key, value))
+
+        # If there are duplicate keys, throw an exception
+        pair_keys = [pair[0] for pair in pairs]
+        seen = set()
+        duplicates = set()
+        seen_add = seen.add
+        duplicate_add = duplicates.add
+        for x in pair_keys:
+            if x not in seen:
+                seen_add(x)
+            else:
+                duplicates_add(x)
+
+        if len(duplicates):
+            duplicates_list = list(duplicates)
+            error_duplicate_keys = ','.join(key for key in duplicates_list)
+            raise ParseError(
+                "Duplicate keys found ({})".format(error_duplicate_keys)
+            )
+
         return pairs
 
     def construct_sequence(self, node, deep=True):

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -146,3 +146,16 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
         content_string = strings[1]
         self.assertEqual(content_string.context, '!tag')
         self.assertEqual(content_string.flags, "'")
+
+    def test_parse_duplicate_keys(self):
+        content = '''\
+            something:
+              attribute_1: Attribute 1 value
+              attribute_2: Attribute 2 value
+              attribute_3: Attribute 3 value
+              attribute_1: Attribute 1 value
+              attribute_2: Attribute 2 value
+        '''
+
+        with self.assertRaises(ParseError):
+            self.handler.parse(content)


### PR DESCRIPTION

Merged Pull Requests:

* transifex/openformats#183 - Throw ParseError on duplicate YAML keys
