### PR TITLE
Fix typo for duplicate YAML keys

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -174,11 +174,11 @@ class TxYamlLoader(yaml.SafeLoader):
             if x not in seen:
                 seen_add(x)
             else:
-                duplicates_add(x)
+                duplicate_add(x)
 
         if len(duplicates):
             duplicates_list = list(duplicates)
-            error_duplicate_keys = ','.join(key for key in duplicates_list)
+            error_duplicate_keys = ', '.join(key for key in duplicates_list)
             raise ParseError(
                 "Duplicate keys found ({})".format(error_duplicate_keys)
             )

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -157,5 +157,9 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
               attribute_2: Attribute 2 value
         '''
 
-        with self.assertRaises(ParseError):
+        with self.assertRaises(ParseError) as e:
             self.handler.parse(content)
+        self.assertEqual(
+            str(e.exception),
+            "Duplicate keys found (attribute_2, attribute_1)"
+        )


### PR DESCRIPTION
Problem and/or solution
-----------------------
We fix a typo that was introduced on https://github.com/transifex/openformats/pull/183.

How to test
-----------
Run `python setup.py test`. The test `test_parse_duplicate_keys` (`openformats.tests.formats.yaml.test_yaml.YamlTestCase`) has been modified to capture the output of the exception.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
