### PR TITLE
Anchors with value are preserved in template

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -73,6 +73,24 @@ class TxYamlLoader(yaml.SafeLoader):
             )
         return super(TxYamlLoader, self).compose_node(parent, index)
 
+    def compose_scalar_node(self, anchor):
+        """
+            Override parent compose_scalar_node method to maintain
+            the anchor label
+        """
+        if anchor is None:
+            return super(TxYamlLoader, self).compose_scalar_node(anchor)
+        else:
+           node = super(TxYamlLoader, self).compose_scalar_node(anchor)
+           anchor_value = self.stream[
+               node.start_mark.index:node.end_mark.index
+            ].split(' ', 1)[1]
+           leading_spaces = len(anchor_value) - len(anchor_value.lstrip(' '))
+
+           node.start_mark.index = node.end_mark.index - len(anchor_value) \
+               + leading_spaces
+           return node
+
     def _is_custom_tag(self, tag):
         """
         Check whether a value is tagged with a custom type.

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -81,3 +81,11 @@ bin: !!binary aGVsbG8= # Should ignore
 #σχόλιο
 σχόλιο: "el:κείμενο"
 emojis: "el:\\uD83D\\uDC40 \U0001F3F9\U0001F34D\U0001F34D \\U0001F418"
+
+anchor_with_label:
+  test: "el:something"
+  anchor_test: &another_anchor     "el:this is another anchor with alias and label - value1 - value2"
+  testing_alias:
+    - *another_anchor
+    - *an_anchor
+    - "el:something else"

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -84,3 +84,13 @@ bin: !!binary aGVsbG8= # Should ignore
 #σχόλιο
 σχόλιο: κείμενο
 emojis: \uD83D\uDC40 🏹🍍🍍 \U0001F418
+
+anchor_with_label:
+  test: something
+  anchor_test: &another_anchor     this is another anchor with alias and label
+    - value1
+    - value2
+  testing_alias:
+    - *another_anchor
+    - *an_anchor
+    - "something else"

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -81,3 +81,11 @@ bin: !!binary aGVsbG8= # Should ignore
 #σχόλιο
 σχόλιο: κείμενο
 emojis: \uD83D\uDC40 🏹🍍🍍 \U0001F418
+
+anchor_with_label:
+  test: something
+  anchor_test: &another_anchor     this is another anchor with alias and label - value1 - value2
+  testing_alias:
+    - *another_anchor
+    - *an_anchor
+    - "something else"

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -41,3 +41,8 @@ bar: !xml "foo <xml>bar</xml>"
 hello: World
 σχόλιο: κείμενο
 emojis: \uD83D\uDC40 🏹🍍🍍 \U0001F418
+anchor_with_label:
+  test: something
+  anchor_test: this is another anchor with alias and label - value1 - value2
+  testing_alias:
+    - "something else"

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -75,3 +75,11 @@ bin: !!binary aGVsbG8= # Should ignore
 #σχόλιο
 σχόλιο: 8687f34a9bf89770b456b48ad2395788_tr
 emojis: 8f9f68d76af0fa4a5e4830530618e55c_tr
+
+anchor_with_label:
+  test: 35816ec55d0782ae231c9910897bc467_tr
+  anchor_test: &another_anchor     345e2c2ed4e035c68da1a8377a4d4315_tr
+  testing_alias:
+    - *another_anchor
+    - *an_anchor
+    - bf9a733efd3e3dd9470b532dca9303cb_tr

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -159,7 +159,14 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
 
         with self.assertRaises(ParseError) as e:
             self.handler.parse(content)
-        self.assertEqual(
-            str(e.exception),
-            "Duplicate keys found (attribute_2, attribute_1)"
+
+        self.assertTrue(
+            str(e.exception) in [
+                "Duplicate keys found (attribute_2, attribute_1)",
+                "Duplicate keys found (attribute_1, attribute_2)",
+            ]
         )
+
+    def test_parse_anchor_with_label_is_maintained_on_template(self):
+        remade_orig_content = self.handler.compile(self.tmpl, self.strset)
+        self.assertEqual("&another_anchor    " in remade_orig_content, True)


### PR DESCRIPTION
Anchors with label and value, result in a template string that the label is not included. 

Problem and/or solution
------------------------------
We solve this issue by overriding the default `compose_scalar_node` of YamlHandler. More
specifically, when the compose_scalar_node is called with an anchor we have to look on the stream of the handler and split with the space token with a max limit of 1. This way:

- The first split token is always the anchor label.
- The second token is the value of anchor label. However, this second token might also include leading spaces that should taken into consideration and are actually part of the anchor label,
not of the anchor value.

Consider the following YAML file:

```yaml
&another_anchor        foo
   - bar
   - baz
```

Our goal is to set the start_mark.index to point to foo. Thus, we set the start of the index to be the node.end_mark.index - the length of `foo - bar - baz` + 7 trailing spaces.

We also fix a test (`test_parse_duplicate_keys`) that was randomly crashing.

How to test
-----------
Run `python setup.py test`.

- A new test `test_parse_anchor_with_label_is_maintained_on_template (openformats.tests.formats.yaml.test_yaml.YamlTestCase)` has been added.
- The test `test_parse_duplicate_keys` (`openformats.tests.formats.yaml.test_yaml.YamlTestCase`) has been modified to fix the random crashing.

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
