### PR TITLE
Remove trailing newline in pluralized strings

### DIFF
--- a/openformats/formats/yaml/yaml_i18n.py
+++ b/openformats/formats/yaml/yaml_i18n.py
@@ -173,10 +173,13 @@ class I18nYamlHandler(YamlHandler):
         except re.error:
             pass
         # Apply the indentation to the beginning of each plural rule
-        return u''.join([
+        joined = u''.join([
             u"{indentation}{line}".format(indentation=indentation, line=line)
             for line in plurals
         ])
+        # Remove trailing newlines since there is already one after each
+        # pluralized string on the template
+        return joined.strip('\n')
 
     def _parse_pluralized_leaf_node(self, node, parent_key, style=[],
                                     pluralized=False):

--- a/openformats/tests/formats/yamlinternationalization/files/1_el.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_el.yml
@@ -3,7 +3,6 @@ en:
   pluralized_string:
     one: el:One ȧɠǿ
     other: el:Other ȧɠǿ
-
   another normal string: "el:normal string"
 
   empty_pluralized_string:
@@ -15,11 +14,9 @@ en:
     one: 'el:this is a test'
     other: "el:this is a double quote test"
 
-
   pluralized_string_with_extra_keys:
     one: el:One
     other: el:Other
-
   non_pluralized_string_with_extra_keys:
     extra_key: "el:random value"
     one: "el:One"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
@@ -3,7 +3,6 @@ en:
   pluralized_string:
     one: One ȧɠǿ
     other: Other ȧɠǿ
-
   another normal string: normal string
 
   empty_pluralized_string:
@@ -15,11 +14,9 @@ en:
     one: 'this is a test'
     other: "this is a double quote test"
 
-
   pluralized_string_with_extra_keys:
     one: One
     other: Other
-
   non_pluralized_string_with_extra_keys:
     extra_key: random value
     one: One


### PR DESCRIPTION
When YAML files are parsed, pluralized strings span across multiple
lines. In this case, we shouldn't add a new line after each string
during compilation since the template already includes the required
newline.

Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
