### PR TITLE
Fix folding issues during YAML compilation

### DIFF
--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -376,6 +376,8 @@ class YamlHandler(Handler):
             emitter.write_folded(string.string)
 
         translation = emitter.stream.getvalue() or string.string
+        if translation.startswith(">-") and not translation.endswith("\n"):
+            translation += "\n"
         emitter.stream.close()
         return translation
 


### PR DESCRIPTION
Related issue [TX-12946](https://transifex.atlassian.net/browse/TX-12946)

Problem and/or solution
-----------------------

The compiler depends on pyyaml's "Emitter" class.

- When the emitter tries to print a block value that doesn't end in newline, it will generally add the newline itself in order for the output to be valid YAML. We thus do *not* add the newline ourselves.

- However, when the block value doesn't end in a newline, but does end in a space, the emitter will prefer using a line-fold style ('>-') and **not** add the newline. This is something we hadn't anticipated; we assumed a newline was added by the emitter and did not add it ourselves. Thus the output's formatting was messed up.

This commit checks whether the output of the emitter is at the same time a block value and doesn't end in a newline and, if that's the case, adds a newline.

Also, tests.

How to test
-----------

Basically reproduce what the new unit tests try to do. With both branches, fire up the testbed and try these 2 source files:

```yaml
a: >
  b
c:
  d
```

```yaml
a: >-
  b
c:
  d
```

And the following variations for the first extracted string: `b`, `b\n`, `b ` (plain `b`, `b` with a newline and `b` with a space).

Reviewer checklist
------------------

Code:
* [x] Change is covered by unit-tests
* [x] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [x] Performance issues have been taken under consideration
* [x] Errors and other edge-cases are handled properly

PR:
* [x] Problem and/or solution are well-explained
* [x] Commits have been squashed so that each one has a clear purpose
* [x] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
