### PR TITLE
Change key for extracted OpenStrings on docx handler

### DIFF
--- a/openformats/formats/docx.py
+++ b/openformats/formats/docx.py
@@ -213,7 +213,7 @@ class DocxHandler(Handler):
         rels_soup = BeautifulSoup(docx.get_document_rels(), 'xml')
 
         stringset = []
-        order = itertools.count()
+        order_generator = itertools.count()
         for paragraph in soup.find_all('w:p'):
             paragraph_text = []
             text_elements =  paragraph.find_all('w:t')
@@ -284,10 +284,12 @@ class DocxHandler(Handler):
             if not paragraph_text.strip():
                 continue
 
+            order = next(order_generator)
+
             open_string = OpenString(
+                six.text_type(order),
                 paragraph_text,
-                paragraph_text,
-                order=next(order)
+                order=order
             )
 
             stringset.append(open_string)

--- a/openformats/tests/formats/docx/test_docx.py
+++ b/openformats/tests/formats/docx/test_docx.py
@@ -47,7 +47,7 @@ class DocxTestCase(unittest.TestCase):
             openstring.string,
             u'<tx>Hello world </tx><tx href="https://www.transifex.com/">this is a link</tx>'  # noqa
         )
-        self.assertEqual(openstring.string, openstring.key)
+        self.assertEqual(openstring.key, u"0")
 
         translation = u'<tx>Καλημέρα κόσμε </tx><tx href="https://el.transifex.com/">αυτός είναι ένας κρίκος</tx>'  # noqa
         stringset = [
@@ -79,7 +79,7 @@ class DocxTestCase(unittest.TestCase):
         openstring = stringset[0]
         self.assertEqual(openstring.order, 0)
         self.assertEqual(openstring.string, translation)
-        self.assertEqual(openstring.string, openstring.key)
+        self.assertEqual(openstring.key, u"0")
 
     def test_complex_file(self):
         path = '{}/complex.docx'.format(self.TESTFILE_BASE)


### PR DESCRIPTION
Problem and/or solution
-----------------------
This change is introduced in order to allow docx translation
files to be matched to the source file.

As an example the string `Hello world`:
* Was generating the key `Hello world` and hash=`3e25960a79dbc69b674cd4ec67a72c62`
* Now is generating the key based on the paragraph observed
  in the docx file
  (ie `5` if it was on the 6th paragraph - zero based indexing -
  in traversal order and hash=`94a54f6bce6f91c0da80e85e01326e60`)

This way for a translation file, were we have translated
the string to `Καλησπέρα κόσμε`:
* Was generating the key `Καλησπέρα κόσμε` and hash=`94a54f6bce6f91c0da80e85e01326e60`
* Now is generating the same key (assuming it is observed on the same
  paragraph and hash (ie `5` and hash=`94a54f6bce6f91c0da80e85e01326e60`)
  so the translation will be matching the `6th` source string
  (in our example the `Hello world`)

This changes comes with some side-effects:
* Duplicate strings are not merged into one:
  - Previously the key was based on the content so we were extracting
    only one string in case the same paragraph text was detected
  - Now the key will never be the same for duplicate strings as it's
    based on paragraph traversal order
* Appending a new paragraph on the top of the document will change
  the key for all strings below.
* Translation will be matched solely on appearance order, which may lead
  to mismatch.

Uploaded translation files may be slightly different when downloaded:
Let's assume that the 1st paragraph has the following source string
* `<b>Hello</b> world</b>` where `<b>` tag denotes bold text
If we upload the translation file as:
* `Καλησπέρα κόσμε` without formatting, then on downloading the file:
the tag mismatch policy will kick-in resulting in the following
result:
   `<b>Καλησπέρα κόσμε</b>`

How to test
-----------
Unit tests included.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
