### PR TITLE
TX-12814 - Escaped character is not working properly with the STRUCTURED_JSON file format

### DIFF
--- a/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
@@ -59,6 +59,24 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         self.assertEqual(stringset[0].__dict__, openstring.__dict__)
         self.assertEqual(compiled, source)
 
+    def test_escaped_character_in_key(self):
+        first_level_key = "a\/b"
+        source = '{"%s": {"c": {"string": "%s"}}}' % (first_level_key, self.random_string)
+        openstring = OpenString(
+            "{}.c".format(self.handler._escape_key(first_level_key)), 
+            self.random_string, order=0
+        )
+        random_hash = openstring.template_replacement
+
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [openstring])
+
+        self.assertEqual(template,
+                         '{"a\/b": {"c": {"string": "%s"}}}' % random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__, openstring.__dict__)
+        self.assertEqual(compiled, source)
+
     def test_embedded_dicts(self):
         source = '{"a": {"b": {"string": "%s"}}}' % self.random_string
         openstring = OpenString("a.b", self.random_string, order=0)
@@ -217,19 +235,19 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         # Test various cases of messed-up braces
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, one {You have {file_count file.} other {You have {file_count} files.} }" }}',  # noqa
-            'Invalid format of pluralized entry with key: "total_files.string"'
+            'Invalid format of pluralized entry with key: "total_files"'
         )
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, one {You have file_count} file.} other {You have {file_count} files.} }" }}',  # noqa
-            'Invalid format of pluralized entry with key: "total_files.string"'
+            'Invalid format of pluralized entry with key: "total_files"'
         )
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, one {You have {file_count} file. other {You have {file_count} files.} }" }}',  # noqa
-            'Invalid format of pluralized entry with key: "total_files.string"'
+            'Invalid format of pluralized entry with key: "total_files"'
         )
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, one {You have {file_count} file}. other {You have file_count} files.} }" }}',  # noqa
-            'Invalid format of pluralized entry with key: "total_files.string"'
+            'Invalid format of pluralized entry with key: "total_files"'
         )
 
     def test_invalid_plural_rules(self):
@@ -238,15 +256,15 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         # Anything else, including their TX int equivalents are invalid.
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, 1 {file} 5 {{file_count} files} }" }}',  # noqa
-            'Invalid plural rule(s): "1, 5" in pluralized entry with key: total_files.string'  # noqa
+            'Invalid plural rule(s): "1, 5" in pluralized entry with key: total_files'  # noqa
         )
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, once {file} mother {{file_count} files} }" }}',  # noqa
-            'Invalid plural rule(s): "once, mother" in pluralized entry with key: total_files.string'  # noqa
+            'Invalid plural rule(s): "once, mother" in pluralized entry with key: total_files'  # noqa
         )
         self._test_parse_error_message(
             '{ "total_files": {"string": "{ item_count, plural, =3 {file} other {{file_count} files} }" }}',  # noqa
-            'Invalid plural rule(s): "=3" in pluralized entry with key: total_files.string'  # noqa
+            'Invalid plural rule(s): "=3" in pluralized entry with key: total_files'  # noqa
         )
 
     def test_irrelevant_whitespace_ignored(self):


### PR DESCRIPTION
Related to: https://transifex.atlassian.net/browse/TX-12814 Escaped character is not working properly with the STRUCTURED_JSON file format

Problem and/or solution
-----------------------
When parsing a JSON or STRUCTURED JSON file the `_exctract` function is used to create the resource keys and get the resource string values. The resource key is created by recursively testing the value of the provided dictionary until it reaches a string. Then it combines all the preceding keys, joining them with a dot `.` .  For this to work with, if any of the keys has a dot in its name, it has to be escaped. E.g. given the JSON string:
```{
   "key1":{
      "key.2":{
         "key21":"a",
         "key22":"b",
         "key23":"c"
      },
      "key3":{
         "key31":"d",
         "key32":"e",
         "key33":"f"
      }
   }
}
```
the key for the first resource will be `key1.key\.2.key21` and the value `a`. Given a STRUCTURED JSON string like:
```
{
   "key1":{
      "key.2":{
         "string":"a",
         "comment":"b",
         "time":"c"
      },
      "key3":{
         "string":"d",
         "comment":"e",
         "time":"f"
      }
   }
}
```
the same logic was used to get the `string` value (e.g. key: `key1.key\.2.string`, value `a`) and then the "parent key" was extracted (e.g. `key1.key\.2.`) and used to retrieve the additional content for the resource (e.g. key: `key1.key\.2.comment`, value `b`). However, this would not work if the STRUCTURED JSON string was already escaped because the duplicated escaping would create a different key (e.g. `key1.key\\.2.string`)! Since the structure is know a different approach was used in the case of STRUCTURED JSON files, where the function recursively tries to find the first dictionary that has a key named "string". It then parses the data of this dictionary as a hole.

How to test
-----------
Parse a STRUCTURED JSON file with an escaped character in a key name, e.g `"Class:Location\/Attribute:geo"`

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
