### PR TITLE
Markdown parse anchor links

### DIFF
--- a/openformats/formats/github_markdown.py
+++ b/openformats/formats/github_markdown.py
@@ -55,12 +55,6 @@ def string_handler(token, template):
     if match_header_line:
         return string.replace(match_header_line.group(), '')
 
-    # Extract Text from `[Text](link)` or `"[Text](link)"` lines
-    match_link = re.search(ensure_unicode(r'^"?\[(.+)\]\(.+\)"?$'), string)
-    if match_link:
-        # Get content between brackets
-        return match_link.groups()[0]
-
     # Extract Text from `[Text]: link` or `"[Text]: link"` lines
     match_reference = re.search(ensure_unicode(r'^"?\[([^\[^\]]+)\]:.+"?$'), string)
     if match_reference:

--- a/openformats/tests/formats/github_markdown/files/1_el.md
+++ b/openformats/tests/formats/github_markdown/files/1_el.md
@@ -153,8 +153,8 @@ el:This is a old version of the {{ site.data.variable.product }} documentation.
 
 ### el:Whole line as links in as list
 
-- "[el:Basic writing and formatting syntax](/articles/basic-writing-and-formatting-syntax)"
-- [el:Working with advanced formatting](/articles/working-with-advanced-formatting)
+- el:"[Basic writing and formatting syntax](/articles/basic-writing-and-formatting-syntax)"
+- el:[Working with advanced formatting](/articles/working-with-advanced-formatting)
 
 ### el:Whole line as links
 

--- a/openformats/tests/formats/github_markdown/files/1_tpl.md
+++ b/openformats/tests/formats/github_markdown/files/1_tpl.md
@@ -131,8 +131,8 @@ d6c6d7c6ae13b3b656339b51dbeb85ff_tr | 9441c042cb0b839e13ed95f55de0ee5c_tr
 
 ### fd90f0cdc5f649dd84d4e21ff33b5774_tr
 
-- "[a69644fd392aad985de61e166dc8e8fd_tr](/articles/basic-writing-and-formatting-syntax)"
-- [ed226cb95f3b637703501d9f4ddd3d68_tr](/articles/working-with-advanced-formatting)
+- a69644fd392aad985de61e166dc8e8fd_tr
+- ed226cb95f3b637703501d9f4ddd3d68_tr
 
 ### 18546b56cfde1b046b0372d31f6e7293_tr
 

--- a/openformats/tests/formats/github_markdown_v2/files/1_el.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_el.md
@@ -166,8 +166,8 @@ el:This is a old version of the {{ site.data.variable.product }} documentation.
 
 ### el:Whole line as links in as list
 
-- "[el:Basic writing and formatting syntax](/articles/basic-writing-and-formatting-syntax)"
-- [el:Working with advanced formatting](/articles/working-with-advanced-formatting)
+- el:"[Basic writing and formatting syntax](/articles/basic-writing-and-formatting-syntax)"
+- el:[Working with advanced formatting](/articles/working-with-advanced-formatting)
 
 ### el:Whole line as links
 

--- a/openformats/tests/formats/github_markdown_v2/files/1_tpl.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_tpl.md
@@ -148,8 +148,8 @@ aa5072eebea6f4364b4444a8a0f0f868_tr
 
 ### 33aa6de370798fadf155bbc16f7540c7_tr
 
-- "[709c93c4918ef02a126bec2a7044dca2_tr](/articles/basic-writing-and-formatting-syntax)"
-- [e4429365fc4b359487f20dc8957bdc97_tr](/articles/working-with-advanced-formatting)
+- 709c93c4918ef02a126bec2a7044dca2_tr
+- e4429365fc4b359487f20dc8957bdc97_tr
 
 ### a55e54225390bca0cdaa0c1d0a8d07d4_tr
 


### PR DESCRIPTION
Problem and/or solution
-----------------------

Both GITHUB MARKDOWN parsers removed README anchor links
text. With this commit, we enable parsing of this
text too, so that the text is translatable and
the links work in translation files too.

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
