### PR TITLE
Update ICU plural examples in JSON formats

### DIFF
--- a/openformats/tests/formats/keyvaluejson/files/1_el.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_el.json
@@ -1,8 +1,8 @@
 {
   "singular_key": "el:This is a regular string.",
-  "total_files": "{ item_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
+  "total_files": "{ file_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
   "special_chars": "{ cnt, plural, one {el:This is Sam's book.} other {el:These are Sam's books.} }",
-  "gold_coins": "{ count, plural,\n zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} \n}",
+  "gold_coins": "{ cnt, plural,\n zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} \n}",
   "something": {
     "else": "el:Something else",
     "is": {

--- a/openformats/tests/formats/keyvaluejson/files/1_en.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_en.json
@@ -1,8 +1,8 @@
 {
   "singular_key": "This is a regular string.",
-  "total_files": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
+  "total_files": "{ file_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
   "special_chars": "{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }",
-  "gold_coins": "{ count, plural,\n zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} \n}",
+  "gold_coins": "{ cnt, plural,\n zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} \n}",
   "something": {
     "else": "Something else",
     "is": {

--- a/openformats/tests/formats/keyvaluejson/files/1_tpl.json
+++ b/openformats/tests/formats/keyvaluejson/files/1_tpl.json
@@ -1,8 +1,8 @@
 {
   "singular_key": "ab2800d7ccb83ba2d643174531d08e36_tr",
-  "total_files": "{ item_count, plural, 9af043f75968a7df63dfa2b27c57e2dc_pl }",
+  "total_files": "{ file_count, plural, 9af043f75968a7df63dfa2b27c57e2dc_pl }",
   "special_chars": "{ cnt, plural, 00fe762ad9b56187fed536350bc3a40c_pl }",
-  "gold_coins": "{ count, plural,\n 8060865280cf7fc9e80b79145208a825_pl \n}",
+  "gold_coins": "{ cnt, plural,\n 8060865280cf7fc9e80b79145208a825_pl \n}",
   "something": {
     "else": "27fc99812beff2126b12708a336513c8_tr",
     "is": {

--- a/openformats/tests/formats/structuredkeyvaluejson/files/1_el.json
+++ b/openformats/tests/formats/structuredkeyvaluejson/files/1_el.json
@@ -3,7 +3,7 @@
     "string": "el:This is a regular string."
   },
   "total_files": {
-    "string": "{ item_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
+    "string": "{ file_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
     "context": "Noun"
   },
   "special_chars": {
@@ -11,7 +11,7 @@
     "developer_comment": "This is a string with special characters"
   },
   "gold_coins": {
-    "string": "{ count, plural,\n zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} \n}",
+    "string": "{ cnt, plural,\n zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.} \n}",
     "character_limit": 150
   },
   "something": {

--- a/openformats/tests/formats/structuredkeyvaluejson/files/1_en.json
+++ b/openformats/tests/formats/structuredkeyvaluejson/files/1_en.json
@@ -3,7 +3,7 @@
     "string": "This is a regular string."
   },
   "total_files": {
-    "string": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
+    "string": "{ file_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
     "context": "Noun"
   },
   "special_chars": {
@@ -11,7 +11,7 @@
     "developer_comment": "This is a string with special characters"
   },
   "gold_coins": {
-    "string": "{ count, plural,\n zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} \n}",
+    "string": "{ cnt, plural,\n zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.} \n}",
     "character_limit": 150
   },
   "something": {

--- a/openformats/tests/formats/structuredkeyvaluejson/files/1_tpl.json
+++ b/openformats/tests/formats/structuredkeyvaluejson/files/1_tpl.json
@@ -3,7 +3,7 @@
     "string": "ab2800d7ccb83ba2d643174531d08e36_tr"
   },
   "total_files": {
-    "string": "{ item_count, plural, 4d0dfbc44762841c0cec988d1e18b4a6_pl }",
+    "string": "{ file_count, plural, 4d0dfbc44762841c0cec988d1e18b4a6_pl }",
     "context": "Noun"
   },
   "special_chars": {
@@ -11,7 +11,7 @@
     "developer_comment": "This is a string with special characters"
   },
   "gold_coins": {
-    "string": "{ count, plural,\n 8060865280cf7fc9e80b79145208a825_pl \n}",
+    "string": "{ cnt, plural,\n 8060865280cf7fc9e80b79145208a825_pl \n}",
     "character_limit": 150
   },
   "something": {


### PR DESCRIPTION
Problem and/or solution
-----------------------
Update KEYVALUEJSON and STRUCTUREDJSON examples of pluralized
ICU strings, so that the starting keyword is the same as the
variable name.

For example {count, plural, one {{cnt} item} other {{cnt} items}}
is best written as {cnt, plural, one {{cnt} item} other {{cnt} items}}.
The reason is that many ICU libraries or frameworks will probably
require the two to be identical (`cnt`), not `count` for the keyword
and `cnt` for the variable placeholder.

How to test
-----------
Not much to test, it's a documentation change, really. The unit tests should pass, of course.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
