### PR TITLE
TX-12748 pot file not uploading for dz language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # Editor temp files
 .*.swp
+
+.idea
+*.iml

--- a/openformats/formats/po.py
+++ b/openformats/formats/po.py
@@ -223,10 +223,13 @@ class PoHandler(Handler):
         elif is_empty:
             if not self.only_values:
                 self.only_keys = True
-                string = entry.msgid if not pluralized else {
-                    0: entry.msgid,
-                    1: entry.msgid_plural
-                }
+                if len(entry.msgstr_plural) == 1:
+                    string = {0: entry.msgid}
+                else:
+                    string = entry.msgid if not pluralized else {
+                        0: entry.msgid,
+                        1: entry.msgid_plural
+                    }
             else:
                 raise ParseError(
                     u"The entry with msgid `{}` includes an empty msgstr. "


### PR DESCRIPTION
Related to [TX-12748: pot file not uploading for dz language](https://transifex.atlassian.net/browse/TX-12748)

Problem and/or solution
-----------------------

If we create a resource with source language Dzongha and try to upload a po file with definitions for plurals, uploading will fail.

This happens because of the empty string in the msgstr[0] key. The PO handler expects not empty string, otherwise it needs both the single and plural rules in the language definition. 

The solution is to check the `msgstr_plural` and if it is has only one rule, produce only one `msgstr` string. 

How to test
-----------

* Use devel branch in the openformats.
* Create a new project with source language Dzongkha.
* Get the `api.po` file from the ticket and try to upload in order to create a new resource.
* Uploading the file you should get an error.
* Changing openformats to branch `TX-12748-pot-file-not-uploading-for-dz-language` the resource should be created.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
