### PR TITLE
Fix apping values that comprise only of an anchor

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -81,15 +81,19 @@ class TxYamlLoader(yaml.SafeLoader):
         if anchor is None:
             return super(TxYamlLoader, self).compose_scalar_node(anchor)
         else:
-           node = super(TxYamlLoader, self).compose_scalar_node(anchor)
-           anchor_value = self.stream[
-               node.start_mark.index:node.end_mark.index
-            ].split(' ', 1)[1]
-           leading_spaces = len(anchor_value) - len(anchor_value.lstrip(' '))
+            node = super(TxYamlLoader, self).compose_scalar_node(anchor)
+            if node.tag == u'tag:yaml.org,2002:null':
+                # 'key: &anchor' should be interpreted as 'key:', ie the value
+                # should be ignored
+                return node
+            anchor_value = self.stream[
+                node.start_mark.index:node.end_mark.index
+             ].split(' ', 1)[1]
+            leading_spaces = len(anchor_value) - len(anchor_value.lstrip(' '))
 
-           node.start_mark.index = node.end_mark.index - len(anchor_value) \
-               + leading_spaces
-           return node
+            node.start_mark.index = node.end_mark.index - len(anchor_value) \
+                + leading_spaces
+            return node
 
     def _is_custom_tag(self, tag):
         """

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -237,3 +237,21 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
                                  "  b ",
                                  "c:",
                                  "  d"]) + "\n")
+
+    def test_parse_empty_anchor(self):
+        source = (u"key1: value1\n"
+                  u"key2: &anchor2 value2\n"
+                  u"key3: &anchor3")
+        template, stringset = self.handler.parse(source)
+
+        self.assertEqual(len(stringset), 2)
+        self.assertEqual(stringset[0].string, u"value1")
+        self.assertEqual(stringset[1].string, u"value2")
+
+        expected_template = (u"key1: {}\n"
+                             u"key2: &anchor2 {}\n"
+                             u"key3: &anchor3".
+                             format(stringset[0].template_replacement,
+                                    stringset[1].template_replacement))
+        self.assertEqual(expected_template, template)
+        self.assertEqual(self.handler.compile(template, stringset), source)


### PR DESCRIPTION

Problem and/or solution
-----------------------

The YaML parser is made to ignore anchors since they are irrelevant to localization and they are vulnerable to "billion laughs" attacks. So, when it encounters a:

```yaml
key: &anchor value
```

It will only consider the "value" part to be part of the extracted string. The problem is that, when the anchor **is** encountered, the
parser _expects_ there to be a value afterwards. When this is encountered:

```yaml
key: &anchor
```

according to the YAML spec, it should be equivalent to:

```yaml
key:
```

meaning the value of the key should be `null`.

```python
yaml.safe_load("key: &anchor")
# <<< {'key': None}
```

However, because the handler assumes that there is a value following the anchor, it does a `...split(' ', 1)[1]` which raises a `ValueError`.

The fix is it check against the captured YaMl node after an anchor is encountered and, if it's a null node, return it as-is.

How to test
-----------

Try uploading this file:

```yaml
key1: value1
key2: &anchor2 value2
key3: &anchor3
```

on `devel` and on this branch, which is what the brand-new unittest does anyway.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
