### PR TITLE
Docx hyperlinks reorder format swapping fix

### DIFF
--- a/openformats/formats/docx.py
+++ b/openformats/formats/docx.py
@@ -427,6 +427,7 @@ class DocxHandler(Handler):
                 rpr = te.parent.rPr
                 color = [c for c in contents if c.name == 'color']
                 underline = [c for c in contents if c.name == 'u']
+                rstyle = [c for c in contents if c.name == 'rStyle']
 
                 if rpr.color:
                     rpr.color.extract()
@@ -436,6 +437,10 @@ class DocxHandler(Handler):
                     rpr.u.extract()
                 if underline:
                     rpr.append(underline[0])
+                if rpr.rStyle:
+                    rpr.rStyle.extract()
+                if rstyle:
+                    rpr.append(rstyle[0])
 
             if len(added_hl_text_elements) == len(deleted_hl_text_elements):
                 for added_url, deleted_url in zip(


### PR DESCRIPTION
Docx: added `w:rStyle` tag in `w:rPr` format swapping in case of hyperlinks reordering

Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
