### PR TITLE
Better string segmentation for pptx notes

### DIFF
--- a/openformats/formats/pptx.py
+++ b/openformats/formats/pptx.py
@@ -307,15 +307,16 @@ class PptxHandler(Handler, OfficeOpenXmlHandler):
             soup = BeautifulSoup(pptx.get_slide(slide), 'xml')
             rels_soup = BeautifulSoup(pptx.get_slide_rels(slide), 'xml')
 
-            for paragraph in soup.find_all('p:sp'):
-                open_string = self.parse_paragraph(paragraph, rels_soup)
-                if not open_string:
-                    continue
+            for parent in soup.find_all('p:sp'):
+                for paragraph in parent.find_all('a:p'):
+                    open_string = self.parse_paragraph(paragraph, rels_soup)
+                    if not open_string:
+                        continue
 
-                open_string.order = next(order)
-                if notes_slide:
-                    open_string.tags = ['notes']
-                stringset.append(open_string)
+                    open_string.order = next(order)
+                    if notes_slide:
+                        open_string.tags = ['notes']
+                    stringset.append(open_string)
 
             pptx.set_slide(slide, six.text_type(soup))
 
@@ -333,8 +334,9 @@ class PptxHandler(Handler, OfficeOpenXmlHandler):
             soup = BeautifulSoup(pptx.get_slide(slide), 'xml')
             rels_soup = BeautifulSoup(pptx.get_slide_rels(slide), 'xml')
 
-            for paragraph in soup.find_all('p:sp'):
-                self.compile_paragraph(paragraph, rels_soup, stringset)
+            for parent in soup.find_all('p:sp'):
+                for paragraph in parent.find_all('a:p'):
+                    self.compile_paragraph(paragraph, rels_soup, stringset)
 
             pptx.set_slide(slide, six.text_type(soup))
             pptx.set_slide_rels(slide, six.text_type(rels_soup))

--- a/openformats/tests/formats/pptx/test_pptx.py
+++ b/openformats/tests/formats/pptx/test_pptx.py
@@ -505,7 +505,7 @@ class PptxTestCase(unittest.TestCase):
         handler = PptxHandler()
         template, stringset = handler.parse(content)
 
-        self.assertEqual(len(stringset), 1)
+        self.assertEqual(len(stringset), 2)
 
         openstring = stringset[0]
         self.assertEqual(openstring.order, 0)
@@ -514,8 +514,17 @@ class PptxTestCase(unittest.TestCase):
             ''.join([
                 u'This<tx> slide has only notes and </tx>',
                 u'<tx href="http://www.transifex.com">hyperlinks</tx>'
-                u'<tx>.</tx>',
-                u'<tx>Another </tx>',
+                u'.'
+            ])
+        )
+        self.assertEqual(openstring.tags, ['notes'])
+
+        openstring = stringset[1]
+        self.assertEqual(openstring.order, 1)
+        self.assertEqual(
+            openstring.string,
+            ''.join([
+                u'Another ',
                 u'<tx>sentence</tx> below'
             ])
         )
@@ -524,9 +533,10 @@ class PptxTestCase(unittest.TestCase):
         translated_strings = [
             [
                 u'Αυτό<tx> το slide έχει μόνο notes και </tx>',
-                u'<tx href="http://el.transifex.com">συνδέσμους</tx>'
-                u'<tx>.</tx>',
-                u'<tx>Άλλη μια </tx>',
+                u'<tx href="http://el.transifex.com">συνδέσμους</tx>.'
+            ],
+            [
+                u'Άλλη μια ',
                 u'<tx>πρόταση</tx> από κάτω'
             ]
         ]
@@ -542,7 +552,7 @@ class PptxTestCase(unittest.TestCase):
         content = handler.compile(template, translated_stringset)
         template, stringset = handler.parse(content)
 
-        self.assertEqual(len(stringset), 1)
+        self.assertEqual(len(stringset), 2)
 
         openstring = stringset[0]
         self.assertEqual(openstring.order, 0)
@@ -550,9 +560,16 @@ class PptxTestCase(unittest.TestCase):
             openstring.string,
             ''.join([
                 u'Αυτό<tx> το slide έχει μόνο notes και </tx>',
-                u'<tx href="http://el.transifex.com">συνδέσμους</tx>'
-                u'<tx>.</tx>',
-                u'<tx>Άλλη μια </tx>',
+                u'<tx href="http://el.transifex.com">συνδέσμους</tx>.'
+            ])
+        )
+
+        openstring = stringset[1]
+        self.assertEqual(openstring.order, 1)
+        self.assertEqual(
+            openstring.string,
+            ''.join([
+                u'Άλλη μια ',
                 u'<tx>πρόταση</tx> από κάτω'
             ])
         )


### PR DESCRIPTION

Problem and/or solution
-----------------------

For normal slides a `p:sp` tag contains only a single `a:p` tag
so considering a paragraph to be either `p:sp` or `a:p` does not make
any difference.

For notes a `p:sp` tag can contain multiple `a:p` tags, for each new line
of the notes, so considering a paragraph to be the `a:p` tag will make
better segmented strings.

A simplified version of a notes slide is the following:

```
<p:sp>
  <a:p>
	<a:t>First line</a:t>
  </a:p>
  <a:p>
	<a:t>Second line</a:t>
  </a:p>
</p:sp>

```

How to test
-----------

A file with multi line nodes slide is tested against new segmentation rules

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
