### PR TITLE
Reset empty text element after deletion

### DIFF
--- a/openformats/formats/office_open_xml/parser.py
+++ b/openformats/formats/office_open_xml/parser.py
@@ -197,6 +197,7 @@ class OfficeOpenXmlHandler(object):
                 else:
                     if empty_text_element:
                         cls.remove_text_element(empty_text_element)
+                        empty_text_element = None
 
                 leading_spaces = 0
 


### PR DESCRIPTION
Problem and/or solution
-----------------------

Reset empty text element after deletion

How to test
-----------
I don't have a real example but in theory since we don't reset the `empty_text_element` there can
be cases where we attempt to delete it multiple times. This may lead to an error on beautiful soup  

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
