### PR TITLE
Fix mapping node with anchors parsing

### DIFF
--- a/openformats/tests/formats/yamlinternationalization/files/1_el.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_el.yml
@@ -96,3 +96,7 @@ en:
   alias_key:
     - *an_anchor
     - "el:another true value"
+
+  anchor_mapping: &another_anchor
+    one: el:one
+    other: el:other

--- a/openformats/tests/formats/yamlinternationalization/files/1_en.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en.yml
@@ -100,3 +100,7 @@ en:
   alias_key:
     - *an_anchor
     - "another true value"
+
+  anchor_mapping: &another_anchor
+    one: one
+    other: other

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
@@ -96,3 +96,7 @@ en:
   alias_key:
     - *an_anchor
     - "another true value"
+
+  anchor_mapping: &another_anchor
+    one: one
+    other: other

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
@@ -56,3 +56,6 @@ en:
     - value
   alias_key:
     - "another true value"
+  anchor_mapping:
+    one: one
+    other: other

--- a/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
@@ -87,3 +87,6 @@ en:
   alias_key:
     - *an_anchor
     - ddc3cfcedcf1686d9e3ba6b99a0d091b_tr
+
+  anchor_mapping: &another_anchor
+  798cf4a4e275a90e80b0aac837f06793_pl


### PR DESCRIPTION
Problem and/or solution
-----------------------

Start marks for mapping nodes, containing anchors,
were not ignoring the anchor value resulting
in wrong template generation.

An illustration of the issue is the following.
Give the following file:
```
en:
  foo: &anchor
    one: one
    other: other
```
Previous implementation:
Start mark for the mapping node was placed at:
index: 11, line 1 (ignoring `en`), column: 7
```
en:
  foo: &anchor
       ^
    one: one
    other: other
```
Then later on `construct_mapping` start mark is moved to
```
start - (value_node.start_mark.column - key_node.start_mark.column)
```
11 - 7 - 2 = 2
So the resulting template was replacing on line 1, column 2:
```
en:
  d06ae22aee8cc2abd5abd5a87cd784be_pl
```

Current implementation:
Start mark is move from the anchor value to the first key
start mark. So the mark is placed at:
index: 23, line 2 (ignoring `en`), column: 4

```
en:
  foo: &anchor
    one: one
    ^
    other: other
```
Then later on `construct_mapping` start mark is moved to
```
start - (value_node.start_mark.column - key_node.start_mark.column)
```
23 - 4 - 2 = 17
So the resulting template was replacing on line 2, column 4:
```
en:
  foo: &anchor
  d06ae22aee8cc2abd5abd5a87cd784be_pl
```

This template can now handle anchor values for mapping nodes
and the translation/source file can be correctly compiled.

How to test
-----------
Enhanced unit test with anchor scenarios for mappings.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
