### PR TITLE
fix the creation of json with unscaped content

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -534,11 +534,11 @@ class StructuredJsonHandler(JsonHandler):
                         self.transcriber.copy_until(value_position)
                         if key == self.CONTEXT_KEY and translation:
                             context = translation.context
-                            self._compile_value(context, value, value_position)
+                            self._compile_value(self.escape(context), value, value_position)
                             context_added = True
                         elif key == self.DEVELOPER_COMMENT_KEY and translation:
                             developer_comment = translation.developer_comment
-                            self._compile_value(developer_comment, value, value_position)
+                            self._compile_value(self.escape(developer_comment), value, value_position)
                             developer_comments_added = True
                         elif key == self.CHARACTER_LIMIT_KEY and translation:
                             character_limit = translation.character_limit
@@ -557,13 +557,13 @@ class StructuredJsonHandler(JsonHandler):
                     extra_elements = []
                     if not context_added and translation and translation.context:
                         extra_elements.append(u"\"{}{}\"{}\"".format(
-                            "context", key_value_separator, translation.context))
+                            "context", key_value_separator, self.escape(translation.context)))
                     if not character_limit_added and translation and translation.character_limit:
                         extra_elements.append(u"\"{}{}{}".format(
                             "character_limit", key_value_separator, translation.character_limit))
                     if not developer_comments_added and translation and translation.developer_comment:
                         extra_elements.append(u"\"{}{}\"{}\"".format(
-                            "developer_comment", key_value_separator, translation.developer_comment))
+                            "developer_comment", key_value_separator, self.escape(translation.developer_comment)))
                     if extra_elements:
                         self.transcriber.add("," + line_separator + ("," + line_separator).join(extra_elements))
 

--- a/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
@@ -616,3 +616,53 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         compiled = self.handler.compile(template, with_updated_char_limit)
         self.assertEqual(compiled, expected_compilation)
 
+    def test_unescaped(self):
+        source = u"""
+        {
+            "a": {
+                "string": "testtest",
+                "context": "context",
+                "developer_comment": "comments"
+            },
+            "b": {
+                "string": "testtest2"
+            }
+        }
+        """
+
+        expected_compilation = u"""
+        {
+            "a": {
+                "string": "testtest",
+                "context": "other \\" context",
+                "developer_comment": "other \\" comment"
+            },
+            "b": {
+                "string": "testtest2",
+                "context": "other \\" context",
+                "developer_comment": "other \\" comment"
+            }
+        }
+        """
+        template, stringset = self.handler.parse(source)
+
+        unescaped = [
+            OpenString(
+                key=stringset[0].key,
+                string_or_strings=stringset[0].string,
+                context=u'other " context',
+                developer_comment=u'other " comment',
+                character_limit=stringset[0].character_limit,
+            ),
+            OpenString(
+                key=stringset[1].key,
+                string_or_strings=stringset[1].string,
+                context=u'other " context',
+                developer_comment=u'other " comment',
+                character_limit=stringset[1].character_limit,
+            )
+        ]
+
+        compiled = self.handler.compile(template, unescaped)
+        self.maxDiff = None
+        self.assertEqual(compiled, expected_compilation)


### PR DESCRIPTION
Problem and/or solution
-----------------------

Fix when we try to replace unescaped value for developer comments.

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
