### PR TITLE
Retain keys with an empty string value in compile

### DIFF
--- a/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
@@ -48,6 +48,17 @@ class JsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         )
         self.assertEqual(len(stringset), 1)
 
+    def test_empty_string_returned_in_compile(self):
+        template, stringset = self.handler.parse('{"a": "%s", "b": ""}' %
+                                                 self.random_string)
+        compiled = self.handler.compile(template, [self.random_openstring])
+
+        self.assertEqual(template, '{"a": "%s", "b": ""}' % self.random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__,
+                         self.random_openstring.__dict__)
+        self.assertEqual(compiled, '{"a": "%s", "b": ""}' % self.random_string)
+
     def test_root_object_is_list(self):
         source = '["%s"]' % self.random_string
         random_openstring = OpenString('..0..', self.random_string, order=0)


### PR DESCRIPTION
Problem and/or solution
-----------------------
When parsing a KEYVALUEJSON file where one of it's keys has an empty string as value, e.g:
`key2` in `{"key1":"example 1", "key2":"", "key3":"example 3"}`,
that key was discarded when compiling the file back resulting to:
`{"key1":"example 1 translation", "key3":"example 3 translation"}`.
This fix retains the key with the empty value:
`{"key1":"example 1 translation", "key2":"", "key3":"example 3 translation"}`.

How to test
-----------
Uploading a KEYVALUEJSON file like `{"key1":"example 1", "key2":"", "key3":"example 3"}` the downloaded file should be `{"key1":"example 1 translation", "key2":"", "key3":"example 3 translation"}`.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
