### PR TITLE
TX-13716: handle empty string in `StructuredJsonHandler`

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -513,7 +513,7 @@ class StructuredJsonHandler(JsonHandler):
                     self._compile_recursively(value)
             if current_part.type == dict:
                 (value, _) = current_part.find_children(self.STRING_KEY)[0]
-                if value is None:
+                if not value:
                     for key, key_position, value, value_position in current_part:
                         self.transcriber.copy_until(key_position - 1)
                         self.transcriber.copy_until(value_position)

--- a/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
@@ -666,3 +666,42 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         compiled = self.handler.compile(template, unescaped)
         self.maxDiff = None
         self.assertEqual(compiled, expected_compilation)
+
+    def test_empty_string(self):
+        source = u"""
+        {
+            "a": {
+                "string": ""
+            },
+            "b": {
+                "string": "x0x0",
+                "character_limit": 35
+            }
+        }
+        """
+
+        expected_compilation = u"""
+        {
+            "a": {
+                "string": ""
+            },
+            "b": {
+                "string": "x0x0",
+                "character_limit": 35
+            }
+        }
+        """
+        template, stringset = self.handler.parse(source)
+
+        expected = [
+            OpenString(
+                key=stringset[0].key,
+                string_or_strings=stringset[0].string,
+                context=stringset[0].context,
+                developer_comment=stringset[0].developer_comment,
+                character_limit=stringset[0].character_limit,
+            ),
+        ]
+
+        compiled = self.handler.compile(template, expected)
+        self.assertEqual(compiled, expected_compilation)


### PR DESCRIPTION
Problem and/or solution
-----------------------
`StructuredJsonHandler` appears not to be able to handle templates with empty translation strings. Specifically, the results it produces are appearing as _shifted_, i.e. translations get saved under different keys from those they were meant to.
For instance, consider a resource of the form:
```json
{
    "a": {
        "string": ""
    },
    "b": {
        "string": "random_translation",
        "character_limit": 35
    }
}
```
The problematic output contains:
```json
{
    "a": {
        "string": "random_translation",
        "character_limit": 35
    },
    "b": {
        "string": "3bb52d41e3e7bfc7abffde771b290a2e_tr",
        "character_limit": 35
    }
}
```

How to test
-----------
Feed the handler with a `json` just like the one from the PR description. The output should be the exact same as the input; no _shifted_ translation strings should occur. 

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
