### PR TITLE
KEYVALUEJSON: properly unescape surrogates

### DIFF
--- a/openformats/utils/json.py
+++ b/openformats/utils/json.py
@@ -395,6 +395,14 @@ def _unescape_generator(string):
                 yield u'u'
                 ptr += 2
                 continue
+            # Surrogates: https://unicode.org/faq/utf_bom.html#utf16-2
+            if 0xd800 <= ord(unescaped) <= 0xdfff:
+                unicode_escaped = string[ptr:ptr+12]
+                escaped = json.loads('"' + unicode_escaped + '"')
+                if len(escaped) == 1:
+                    yield escaped
+                    ptr += 12
+                    continue
             yield unescaped
             ptr += 6
 


### PR DESCRIPTION
Problem and/or solution
-----------------------

Lets assume the source file was:

```json
{"bad": "\ud83d\udc49"}
```

Transifex will correctly store the `\\ud83d\\udc49` (12 symbols total, the backslashes here are escaped) string as the "raw" string.

The correct way to unescape this to a "rich" string would be:

```python
json.loads('"' + '\\ud83d\\udc49' + '"')
<<< '👉'  # 1 symbol
```

However, the way we used to do this was

```python
from openformats.utils.json import unescape
unescape('\\ud83d\\udc49')  # 12 symbols
<<< '\ud83d\udc49'  # 2 symbols, bad
```

This is a surrogate sequence, which incidentally is how the '👉' symbol gets encoded into UTF-16 (!!!). When python 2 tried to encode this bad string into UTF-8, it would end up with:

```python
u'\ud83d\udc49'.encode('utf8')  # Python 2
<<<'\xf0\x9f\x91\x89'
```

Which is the correct UTF-8 representation of the '👉' symbol.

```python
'👉'.encode('utf8')  # Python 3
<<< b'\xf0\x9f\x91\x89'
```

Python 3 however doesn't want to encode surrogate symbols to UTF-8. Thus we were getting a lot of `UnicodeEncodeError: 'utf-8' codec can't encode characters in position 55-56: surrogates not allowed` exceptions.

The solution was to change our unescape function to handle surrogate symbols like `json.loads` does, so that we wouldn't end up with bad symbol sequences in our rich strings.

In case you were curious, the reason that surrogate symbols ended up in the JSON file to begin with is, I suspect, that the JSON specification only allows `/uXXXX` escape sequences with exactly 4 hex digits. The proper `\uXXXX` sequence for the '👉' symbol however is:

```python
[125]: ascii('👉')
<<< "'\\U0001f449'"
```

Which has more than 4. So I suspect that JSON serializers fall back to the UTF-16 way of doing things when trying to serialize symbols whose codepoint don't fit into 4 hex digits.

How to test
-----------

Upload this file as a souce file:

```json
{"bad": "\ud83d\udc49"}
```

Then try to get the string details via the APIv2:

```sh
http -a api:$API_TOKEN ':8000/api/2/project/.../resource/.../translation/en/strings?details'
```

The APIv2 will try to return the "rich" version of the source string. However, since the response will need to be converted to UTF-8 in order to go through the network, `devel` will end up raising a UnicodeEncodeError.

On `devel` you should get a 500 error. On this branch you should get a proper response.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
