### PR TITLE
Handle non Unicode spaces

### DIFF
--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import re
 
 import six
-
+import unicodedata
 from mistune import Markdown
 from yaml.reader import Reader
 
@@ -71,7 +71,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         # need to do the same in order to be able to match the substrings
         template = content.expandtabs(4)
         pattern = re.compile(ensure_unicode(r'^ +$'), re.M)
-        content = pattern.sub('', template)
+        content = unicodedata.normalize('NFKC', pattern.sub('', template))
 
         stringset = []
 

--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -34,6 +34,13 @@ class GithubMarkdownV2TestCase(CommonFormatTestMixin, unittest.TestCase):
         content_with_spaces = self.handler.parse(content=u"# foo    bar")
         self.assertEqual(content_with_tab[0], content_with_spaces[0])
 
+    def test_parse_non_unicode(self):
+        """Test parse converts tabs to spaces"""
+        content_with_non_unicode_space = self.handler.parse(content=u"# foo\xa0bar")
+        content_with_normal_space = self.handler.parse(content=u"# foo bar")
+        self.assertEqual(
+            content_with_non_unicode_space[0], content_with_normal_space[0])
+
 
 class GithubMarkdownV2CustomTestCase(unittest.TestCase):
     """Tests some additional functionality of GithubMarkdownHandlerV2.


### PR DESCRIPTION
Problem and/or solution
-----------------------
Some Latin (ISO 8859-1) characters (e.g. `\xa0` : non-breakable space) cause the Github Markdown parser to skip the lines that contain them. By using `unicodedata.normalize` we convert these characters to their normal form.

How to test
-----------
Parsing an `.md` file that contains lines with characters like the above should be completed without skipping these lines.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
