### PR TITLE
Problem with empty dicts when compiling

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -306,7 +306,7 @@ class JsonHandler(Handler):
         return at_least_one
 
     def _insert_from_dict(self, parsed, is_real_stringset):
-        at_least_one = False
+        at_least_one = not bool(list(parsed))
 
         for key, key_position, value, value_position in parsed:
 
@@ -323,7 +323,7 @@ class JsonHandler(Handler):
         return at_least_one
 
     def _insert_from_list(self, parsed, is_real_stringset):
-        at_least_one = False
+        at_least_one = not bool(list(parsed))
 
         for value, value_position in parsed:
             self.transcriber.copy_until(value_position - 1)

--- a/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
@@ -257,14 +257,23 @@ class JsonTestCase(CommonFormatTestMixin, unittest.TestCase):
     def test_skip_start_of_list(self):
         string1 = self.random_string
         string2 = generate_random_string()
-        openstring2 = OpenString('..1..', string2, order=1)
 
         source = '["%s", "%s"]' % (string1, string2)
 
         template, stringset = self.handler.parse(source)
-        compiled = self.handler.compile(template, [openstring2])
+        compiled = self.handler.compile(template, [stringset[1]])
 
         self.assertEqual(compiled, '[ "%s"]' % string2)
+
+    def test_empty_dict_at_start_of_list(self):
+        string = self.random_string
+
+        source = '[{}, "%s"]' % string
+
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, stringset)
+
+        self.assertEqual(compiled, '[{}, "%s"]' % string)
 
     def test_skip_end_of_list(self):
         string1 = self.random_string


### PR DESCRIPTION
The KEYVALUEJSON compiler must remove sections of untranslated strings.
Thus, if you have a template like:

```json
{
    "key1": "hash1",
    "key2": "hash2"
}
```

and compile against a stringset that only has one of the two strings
translated, you should end up with a valid JSON file with only one of
the strings, like:

```json
{
    "key2": "translation2"
}
```

This gets a little more complicated with containers, like lists or
dicts. For example, assuming this template:

```json
{
    "key1": "hash1",
    "key3-4": ["hash3", "hash4"]
    "key4": "hash4"
}
```

If you compile against a stringset with translations for strings 1 and
4, then the whole list and its key should be removed:

```json
{
    "key1": "translation1",
    "key4": "translation4"
}
```

This is done by iterating over the container and, if no translations
were inserted during the iterations, get rid of the whole container.
This creates a problem when the container is empty in the template, this
logic generates a false-positive answer: "Yes, no hashes were replaced
with translations (because no hashes were there to begin with)". So, the
compiler attempts to remove the empty container from the compiled file,
with unexpected results.

This fix treats empty containers as ones where translations **were**
performed. ie, in response to the question:

- Did any replacements take place during the iteration?

Instead of answering:

- No, no replacements took place (none could have since the container
  was empty).

We now answer:

- Yes, all hashes in this container were replaced (technically true).

A test was also added to reproduce this issue.

Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
