### PR TITLE
Add pipe check to GITHUBMARKDOWNV2

### DIFF
--- a/openformats/formats/github_markdown_v2.py
+++ b/openformats/formats/github_markdown_v2.py
@@ -35,6 +35,7 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
     AT_SIGN = '@'  # reserved character in the YAML spec
     BRACKET_LEFT = '['
     BRACKET_RIGHT = ']'
+    PIPE = '|'
 
     # A string that looks like '\u0008'
     ESCAPED_UNICODE = re.compile(r'\\u[a-fA-F0-9]{4}')
@@ -238,9 +239,8 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
         # this is to ensure that if the style is literal or folded
         # http://www.yaml.org/spec/1.2/spec.html#id2795688
         # a new line always follows the string
-        if (openstring.flags and openstring.flags[-1] in '|>'
-                and string[-1] != self.NEWLINE):
-            string = string + self.NEWLINE
+        if (openstring.flags and openstring.flags[-1] in '|>'):
+            string = openstring.flags[-1] + self.NEWLINE + string
 
         return string
 
@@ -280,6 +280,10 @@ class GithubMarkdownHandlerV2(OrderedCompilerMixin, Handler):
             the character that should be used for wrapping
         :rtype: tuple (bool, str)
         """
+        # If pipe flag appears do not wrap it.
+        if self.PIPE in openstring.flags:
+            return False, openstring.flags
+
         # If single or double quote flags appear, wrap it.
         if openstring.flags in [self.DOUBLE_QUOTES, self.SINGLE_QUOTE]:
             return True, openstring.flags

--- a/openformats/tests/formats/github_markdown_v2/files/1_el.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_el.md
@@ -16,14 +16,14 @@ key2:
   - "el:text with a #hashtag in it"
   - "el:li 5"
 
-description: "el:folded style text
-"
-custom_vars:
+description: >
+"el:folded style text
+"custom_vars:
   var1: "el:text: some value"
-  var2: "el:literal
-style with \"quotes\"
+  var2: |
+el:literal
+style with "quotes"
 text
-"
 nested_key_outer:
   nested_key_inner:
     "el:nested_value"

--- a/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
+++ b/openformats/tests/formats/github_markdown_v2/files/1_en_export.md
@@ -16,13 +16,14 @@ key2:
   - "text with a #hashtag in it"
   - li 5
 
-description: folded style text
+description: >
+folded style text
 custom_vars:
   var1: "text: some value"
-  var2: "literal
-style with \"quotes\"
+  var2: |
+literal
+style with "quotes"
 text
-"
 nested_key_outer:
   nested_key_inner:
     nested_value

--- a/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
+++ b/openformats/tests/formats/github_markdown_v2/test_github_markdown.py
@@ -123,6 +123,13 @@ class GithubMarkdownV2CustomTestCase(unittest.TestCase):
         self.assertTrue(should_wrap)
         self.assertEqual(wrap_char, u'"')
 
+    def test_should_not_wrap_in_quotes_if_has_pipe_char(self):
+        openstring = OpenString('k', u'{} Something else'.format(GithubMarkdownHandlerV2.PIPE))
+        should_wrap, wrap_char = self.handler._should_wrap_in_quotes(
+            openstring
+        )
+        self.assertFalse(should_wrap)
+
     def test_wrap_in_quotes(self):
         """Make sure that the string is wrapped and that any existing quote chars
         are escaped."""


### PR DESCRIPTION
[TX-13920](https://transifex.atlassian.net/jira/software/c/projects/TX/boards/93?modal=detail&selectedIssue=TX-13920)

Problem and/or solution
-----------------------

When pulling translations from GITHUBMARKDOWN resources, the YAML frontmatter formatting doesn't get preserved. Especially finding this when the frontmatter uses the YAML syntax of `|` for values with multiple lines.

A possible solution is to check whether | is present in the string's flags and add it during the compilation.

How to test
-----------

See instructions in ticket.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
