### PR TITLE
Revert skip of empty strings for json formats

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -258,7 +258,7 @@ class JsonHandler(Handler):
         at_least_one = False
 
         if isinstance(value, (six.binary_type, six.text_type)):
-            if value != '':
+            if value.strip():
                 string = self._get_next_string()
                 string_exists = string is not None
 


### PR DESCRIPTION
Problem and/or solution
-----------------------
Empty keys like ' ' are not removed on complication

How to test
-----------
1. make run and open 127.0.0.1:8010
2. add the content:
```json
{
  "key1":"test1",
  "key2": " ",
  "key3": "test3"
}
```
You should see key1 & key3 in parsed items and all 3 keys in template after you compile

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
