### PR TITLE
Respect whitespace only strings during compilation

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -297,9 +297,17 @@ class JsonHandler(Handler):
                 # value is an empty string, add the key but don't update
                 # stringset_index
                 at_least_one = True
-                self._insert_regular_string(
-                    value, value_position, '', False
-                )
+
+                if len(value) > 0:
+                    # Add whitespace back
+                    self._insert_regular_string(
+                        value, value_position, value, False
+                    )
+                else:
+                    at_least_one = True
+                    self._insert_regular_string(
+                        value, value_position, '', False
+                    )
 
         elif isinstance(value, DumbJson):
             items_still_left = self._insert(value, is_real_stringset)

--- a/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/keyvaluejson/test_keyvaluejson.py
@@ -199,6 +199,15 @@ class JsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         self.assertEqual(stringset[0].__dict__, random_openstring.__dict__)
         self.assertEqual(compiled, '{"a": [null]}')
 
+    def test_respect_whitespace_only_strings(self):
+        source = '{"a": " "}'
+
+        template, _ = self.handler.parse(source)
+        compiled = self.handler.compile(template, [])
+
+        self.assertEqual(template, '{"a": " "}')
+        self.assertEqual(compiled, '{"a": " "}')
+
     def test_remove_all_strings_removed_from_dict_but_non_strings_exist(self):
         random_string = self.random_string
         random_openstring = self.random_openstring


### PR DESCRIPTION
Related issue: [TX-14627](https://transifex.atlassian.net/browse/TX-14627)

Problem and/or solution
-----------------------

When we have a json source file that contains an entry entirely of whitespace we do not show it in the editor and when we download either the resource or the translation file, it writes an empty string.

How to test
-----------

1. Upload a json file that contains an entry with whitespace, for example:
1.1. `{'string':  '    '}`
2. Download either the resource or the translation file
3. The whitespace should be there

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)


[TX-14627]: https://transifex.atlassian.net/browse/TX-14627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ