### PR TITLE
Prevent corrupted pptx compilation

### DIFF
--- a/openformats/formats/pptx.py
+++ b/openformats/formats/pptx.py
@@ -329,7 +329,8 @@ class PptxHandler(Handler, OfficeOpenXmlHandler):
 
     @classmethod
     def remove_text_element(cls, text_element):
-        text_element.decompose()
+        parent = text_element.find_parent('a:r')
+        parent.decompose()
 
     @classmethod
     def set_rtl_orientation(cls, paragraph):


### PR DESCRIPTION
When a translation contains less parts (separate by <tx> tags) the remaining parts of the source, that are present in the source file, must be removed from the xml.

Until now the removal was removing the text element by itself (<a:t>) leaving other elements intact.

This resulted in the presence of some <a:r> blocks that had not content in them and should be the reason why the pptx files is considered corrupted.

With this commit instead of removeing the <a:t> element only we instead remove the surround <a:r> block all together that will lead to compilation of non corrupted files.

Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
