### PR TITLE
fix keyvaluejson empty stringset check should be done on the top level

### DIFF
--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -61,6 +61,10 @@ class JsonHandler(Handler):
             raise ParseError(six.text_type(e))
         self._order = count()
         self._extract(parsed)
+
+        if not self.stringset and self.name == "STRUCTURED_JSON":
+            raise ParseError('No strings could be extracted')
+
         self.transcriber.copy_until(len(source))
 
         return self.transcriber.get_destination(), self.stringset
@@ -145,9 +149,6 @@ class JsonHandler(Handler):
                     pass
         else:
             raise ParseError("Invalid JSON")
-
-        if not self.stringset and self.name == "STRUCTURED_JSON":
-            raise ParseError('No strings could be extracted')
 
     def _create_openstring(self, key, value, value_position):
         """Return a new OpenString based on the given key and value

--- a/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
+++ b/openformats/tests/formats/structuredkeyvaluejson/test_keyvaluejson.py
@@ -679,14 +679,14 @@ class StructuredJsonTestCase(CommonFormatTestMixin, unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(compiled, expected_compilation)
 
-    def test_empty_string(self):
+    def test_empty_strings(self):
         source = u"""
         {
             "a": {
                 "string": ""
             },
             "b": {
-                "string": "x0x0",
+                "string": "",
                 "character_limit": 35
             }
         }


### PR DESCRIPTION
Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
