### PR TITLE
CHAM-586 Allow numbers and symbols on yaml context

### DIFF
--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -142,13 +142,21 @@ class TxYamlLoader(yaml.SafeLoader):
         Detect custom tags, like:
             `foo: !bar test`
             `foo: !xml "<bar>Bar</bar>"`
+
+        The name of the custom tag can have any of the following characters:
+        `a-z`, `A-Z`, `0-9`, `_`, `.`, `:`, `-`.
+        In any other case, we return `False`.
+
         Built-in types, indicated by a `!!` prefix, will not be matched. We
         can't preserve the information whether a built-in tag like `!!str` was
         used for a value since the PyYAML library will tag such entries with
         the built-in identifier. For example `tag:yaml.org,2002:str`, not
         `!!str`.
         """
-        return tag.startswith('!') and not tag.startswith('!!')
+
+        return re.match(ensure_unicode(r'^\![a-zA-Z0-9_:.\-]*$'),
+                        tag,
+                        re.IGNORECASE)
 
     def construct_mapping(self, node, deep=True):
         """

--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -148,9 +148,7 @@ class TxYamlLoader(yaml.SafeLoader):
         the built-in identifier. For example `tag:yaml.org,2002:str`, not
         `!!str`.
         """
-        return re.match(ensure_unicode(r'^[\![a-zA-Z_]*]*$'),
-                        tag,
-                        re.IGNORECASE)
+        return tag.startswith('!') and not tag.startswith('!!')
 
     def construct_mapping(self, node, deep=True):
         """

--- a/openformats/formats/yaml/utils.py
+++ b/openformats/formats/yaml/utils.py
@@ -220,6 +220,8 @@ class TxYamlLoader(yaml.SafeLoader):
                 and self._is_custom_tag(value_node.tag)
             ):
                 tag = six.text_type(value_node.tag)
+                # remove the exclamation mark from the tag
+                tag = tag[1:] if tag.startswith('!') else tag
 
             value = Node(value, start, end, style, tag)
             pairs.append((key, value))
@@ -347,8 +349,9 @@ class YamlGenerator(object):
                         yaml_dict, keys, flags, se.string.get(rule), tag=None,
                     )
             else:
+                tag = '!' + se.context if se.context else se.context
                 self._insert_translation_in_dict(
-                    yaml_dict, keys, flags, se.string, tag=se.context,
+                    yaml_dict, keys, flags, se.string, tag=tag,
                 )
         return yaml_dict
 

--- a/openformats/formats/yaml/yaml.py
+++ b/openformats/formats/yaml/yaml.py
@@ -404,7 +404,8 @@ class YamlHandler(Handler):
             # it and apply a space afterwards so it doesn't get merged with the
             # string
             if string.context:
-                transcriber.add(string.context)
+                # add an exclamation mark to the context to make it a tag
+                transcriber.add('!' + string.context)
                 transcriber.add(' ')
             transcriber.add(translation)
             transcriber.skip(len(string.template_replacement))

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -77,6 +77,13 @@ hello: "el:World" # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
+# Custom tags with numbers and symbols
+context_string: !he:fd94;fd/la "el:context string"
+verbim_context_string: !contex!t545qa "el:verbim context string"
+context_on_nested_map:
+  first: !first_context:54KJFLA95KJ4 "el:context in nested map"
+  second: !second_context:FDKJ40DK "el:context in nested map"
+
 # Test with non-ASCII keys
 #σχόλιο
 σχόλιο: "el:κείμενο"

--- a/openformats/tests/formats/yaml/files/1_el.yml
+++ b/openformats/tests/formats/yaml/files/1_el.yml
@@ -78,8 +78,8 @@ number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
 # Custom tags with numbers and symbols
-context_string: !he:fd94;fd/la "el:context string"
-verbim_context_string: !contex!t545qa "el:verbim context string"
+context_string: !cs:fd-94_fd.dot. "el:context string"
+verbim_context_string: !context:t5-46_qa "el:verbim context string"
 context_on_nested_map:
   first: !first_context:54KJFLA95KJ4 "el:context in nested map"
   second: !second_context:FDKJ40DK "el:context in nested map"

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -80,6 +80,13 @@ hello: !!str World # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
+# Custom tags with numbers and symbols
+context_string: !he:fd94;fd/la "context string"
+verbim_context_string: !<!contex!t545qa> "verbim context string"
+context_on_nested_map:
+  first: !first_context:54KJFLA95KJ4 "context in nested map"
+  second: !second_context:FDKJ40DK "context in nested map"
+
 # Test with non-ASCII keys
 #σχόλιο
 σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_en.yml
+++ b/openformats/tests/formats/yaml/files/1_en.yml
@@ -81,8 +81,8 @@ number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
 # Custom tags with numbers and symbols
-context_string: !he:fd94;fd/la "context string"
-verbim_context_string: !<!contex!t545qa> "verbim context string"
+context_string: !cs:fd-94_fd.dot. "context string"
+verbim_context_string: !<!context:t5-46_qa> "verbim context string"
 context_on_nested_map:
   first: !first_context:54KJFLA95KJ4 "context in nested map"
   second: !second_context:FDKJ40DK "context in nested map"

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -78,8 +78,8 @@ number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
 # Custom tags with numbers and symbols
-context_string: !he:fd94;fd/la "context string"
-verbim_context_string: !contex!t545qa "verbim context string"
+context_string: !cs:fd-94_fd.dot. "context string"
+verbim_context_string: !context:t5-46_qa "verbim context string"
 context_on_nested_map:
   first: !first_context:54KJFLA95KJ4 "context in nested map"
   second: !second_context:FDKJ40DK "context in nested map"

--- a/openformats/tests/formats/yaml/files/1_en_exported.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported.yml
@@ -77,6 +77,13 @@ hello: World # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
+# Custom tags with numbers and symbols
+context_string: !he:fd94;fd/la "context string"
+verbim_context_string: !contex!t545qa "verbim context string"
+context_on_nested_map:
+  first: !first_context:54KJFLA95KJ4 "context in nested map"
+  second: !second_context:FDKJ40DK "context in nested map"
+
 # Test with non-ASCII keys
 #σχόλιο
 σχόλιο: κείμενο

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -39,6 +39,11 @@ alias_key:
 foo: !test 'bar'
 bar: !xml "foo <xml>bar</xml>"
 hello: World
+context_string: !he:fd94;fd/la "context string"
+verbim_context_string: !contex%21t545qa "verbim context string"
+context_on_nested_map:
+  first: "context in nested map"
+  second: "context in nested map"
 σχόλιο: κείμενο
 emojis: \uD83D\uDC40 🏹🍍🍍 \U0001F418
 anchor_with_label:

--- a/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yaml/files/1_en_exported_without_template.yml
@@ -39,8 +39,8 @@ alias_key:
 foo: !test 'bar'
 bar: !xml "foo <xml>bar</xml>"
 hello: World
-context_string: !he:fd94;fd/la "context string"
-verbim_context_string: !contex%21t545qa "verbim context string"
+context_string: !cs:fd-94_fd.dot. "context string"
+verbim_context_string: !context:t5-46_qa "verbim context string"
 context_on_nested_map:
   first: "context in nested map"
   second: "context in nested map"

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -65,11 +65,18 @@ alias_key:
   - ddc3cfcedcf1686d9e3ba6b99a0d091b_tr
 
 # Custom tags
-foo:  3e4000f6f4cd8bb27db6fb82e1b50bb4_tr # Should treat as string and ignore leading spaces
-bar: 75ce597a505a4faf6369b66b885926c8_tr # Also a string
+foo:  023503fb466f78932b77209b6581156e_tr # Should treat as string and ignore leading spaces
+bar: fac8140a2ec031af14bc758e73f59017_tr # Also a string
 hello: b0ed9cf22c0a5186d1c5b483a910dd33_tr # Translatable
 number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
+
+# Custom tags with numbers and symbols
+context_string: 629aded197db84c4d323cd3ed4cf0485_tr
+verbim_context_string: d37275706209cb19ee621ff3835522fe_tr
+context_on_nested_map:
+  first: 95175e30d6fbfe0f658e75919cd4982c_tr
+  second: dce391c231a7ad7fef9e6cc0ddcbf549_tr
 
 # Test with non-ASCII keys
 #σχόλιο

--- a/openformats/tests/formats/yaml/files/1_tpl.yml
+++ b/openformats/tests/formats/yaml/files/1_tpl.yml
@@ -72,8 +72,8 @@ number: !!int 123 # Should ignore
 bin: !!binary aGVsbG8= # Should ignore
 
 # Custom tags with numbers and symbols
-context_string: 629aded197db84c4d323cd3ed4cf0485_tr
-verbim_context_string: d37275706209cb19ee621ff3835522fe_tr
+context_string: 17d854ee46fe3d3bc91fadb4cf4df426_tr
+verbim_context_string: 0a3c1ae205b2c0d09ab69ab540e481f2_tr
 context_on_nested_map:
   first: 95175e30d6fbfe0f658e75919cd4982c_tr
   second: dce391c231a7ad7fef9e6cc0ddcbf549_tr

--- a/openformats/tests/formats/yaml/test_yaml.py
+++ b/openformats/tests/formats/yaml/test_yaml.py
@@ -144,7 +144,7 @@ class YamlTestCase(CommonFormatTestMixin, unittest.TestCase):
         self.assertEqual(test_string.flags, '')
 
         content_string = strings[1]
-        self.assertEqual(content_string.context, '!tag')
+        self.assertEqual(content_string.context, 'tag')
         self.assertEqual(content_string.flags, "'")
 
     def test_parse_duplicate_keys(self):

--- a/openformats/tests/formats/yamlinternationalization/files/1_el.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_el.yml
@@ -102,8 +102,8 @@ en:
     other: el:other
 
   # context
-  context_string: !he:fd94;fd/la "el:context string"
-  verbim_context_string: !contex!t545qa "el:verbim context string"
+  context_string: !cs:fd-94_fd.dot. "el:context string"
+  verbim_context_string: !context:t5-46_qa "el:verbim context string"
   context_on_nested_map:
     first: !first_context:54KJFLA95KJ4 "el:context in nested map"
     second: !second_context:FDKJ40DK "el:context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_el.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_el.yml
@@ -100,3 +100,10 @@ en:
   anchor_mapping: &another_anchor
     one: el:one
     other: el:other
+
+  # context
+  context_string: !he:fd94;fd/la "el:context string"
+  verbim_context_string: !contex!t545qa "el:verbim context string"
+  context_on_nested_map:
+    first: !first_context:54KJFLA95KJ4 "el:context in nested map"
+    second: !second_context:FDKJ40DK "el:context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en.yml
@@ -104,3 +104,10 @@ en:
   anchor_mapping: &another_anchor
     one: one
     other: other
+
+  # context
+  context_string: !he:fd94;fd/la "context string"
+  verbim_context_string: !<!contex!t545qa> "verbim context string"
+  context_on_nested_map:
+    first: !first_context:54KJFLA95KJ4 "context in nested map"
+    second: !second_context:FDKJ40DK "context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en.yml
@@ -106,8 +106,8 @@ en:
     other: other
 
   # context
-  context_string: !he:fd94;fd/la "context string"
-  verbim_context_string: !<!contex!t545qa> "verbim context string"
+  context_string: !cs:fd-94_fd.dot. "context string"
+  verbim_context_string: !<!context:t5-46_qa> "verbim context string"
   context_on_nested_map:
     first: !first_context:54KJFLA95KJ4 "context in nested map"
     second: !second_context:FDKJ40DK "context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
@@ -102,8 +102,8 @@ en:
     other: other
 
   # context
-  context_string: !he:fd94;fd/la "context string"
-  verbim_context_string: !contex!t545qa "verbim context string"
+  context_string: !cs:fd-94_fd.dot. "context string"
+  verbim_context_string: !context:t5-46_qa "verbim context string"
   context_on_nested_map:
     first: !first_context:54KJFLA95KJ4 "context in nested map"
     second: !second_context:FDKJ40DK "context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported.yml
@@ -100,3 +100,10 @@ en:
   anchor_mapping: &another_anchor
     one: one
     other: other
+
+  # context
+  context_string: !he:fd94;fd/la "context string"
+  verbim_context_string: !contex!t545qa "verbim context string"
+  context_on_nested_map:
+    first: !first_context:54KJFLA95KJ4 "context in nested map"
+    second: !second_context:FDKJ40DK "context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
@@ -59,3 +59,8 @@ en:
   anchor_mapping:
     one: one
     other: other
+  context_string: !he:fd94;fd/la "context string"
+  verbim_context_string: !contex%21t545qa "verbim context string"
+  context_on_nested_map:
+    first: "context in nested map"
+    second: "context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_en_exported_without_template.yml
@@ -59,8 +59,8 @@ en:
   anchor_mapping:
     one: one
     other: other
-  context_string: !he:fd94;fd/la "context string"
-  verbim_context_string: !contex%21t545qa "verbim context string"
+  context_string: !cs:fd-94_fd.dot. "context string"
+  verbim_context_string: !context:t5-46_qa "verbim context string"
   context_on_nested_map:
     first: "context in nested map"
     second: "context in nested map"

--- a/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
@@ -92,8 +92,8 @@ en:
   798cf4a4e275a90e80b0aac837f06793_pl
 
   # context
-  context_string: 629aded197db84c4d323cd3ed4cf0485_tr
-  verbim_context_string: d37275706209cb19ee621ff3835522fe_tr
+  context_string: 17d854ee46fe3d3bc91fadb4cf4df426_tr
+  verbim_context_string: 0a3c1ae205b2c0d09ab69ab540e481f2_tr
   context_on_nested_map:
     first: 95175e30d6fbfe0f658e75919cd4982c_tr
     second: dce391c231a7ad7fef9e6cc0ddcbf549_tr

--- a/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
@@ -90,3 +90,10 @@ en:
 
   anchor_mapping: &another_anchor
   798cf4a4e275a90e80b0aac837f06793_pl
+
+  # context
+  context_string: 1e31a39d57f088cfc6c2eb9585c0b467_tr
+  verbim_context_string: e147f6d42ae7e10950e4157fcce2e534_tr
+  context_on_nested_map:
+    first: bbb714442aca9ca3d3dbf18aa54811d6_tr
+    second: 8a7ebe3f36daee5d0aed8c11384db83d_tr

--- a/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
+++ b/openformats/tests/formats/yamlinternationalization/files/1_tpl.yml
@@ -92,8 +92,8 @@ en:
   798cf4a4e275a90e80b0aac837f06793_pl
 
   # context
-  context_string: 1e31a39d57f088cfc6c2eb9585c0b467_tr
-  verbim_context_string: e147f6d42ae7e10950e4157fcce2e534_tr
+  context_string: 629aded197db84c4d323cd3ed4cf0485_tr
+  verbim_context_string: d37275706209cb19ee621ff3835522fe_tr
   context_on_nested_map:
-    first: bbb714442aca9ca3d3dbf18aa54811d6_tr
-    second: 8a7ebe3f36daee5d0aed8c11384db83d_tr
+    first: 95175e30d6fbfe0f658e75919cd4982c_tr
+    second: dce391c231a7ad7fef9e6cc0ddcbf549_tr


### PR DESCRIPTION
Problem and/or solution
-----------------------
So far, we've been able to include context in YAML files (YAML_GENERIC, YML i18n) [tx doc](https://help.transifex.com/en/articles/6223189-yaml#h_b26ad4b4a4) by utilizing custom [YAML tags](https://yaml.org/spec/1.2.2/#node-tags) .
 For instance:

```yaml
string: !context translation 
```
However, our Yaml parser for the context only allows alphabetic characters, zeros, and underscores. For instance:

```yaml
a_string_without_context: !context1 translation  # context -> None
a_string_with_context: !context_smth translations  # context -> !context_smth
```
We have now extended support to include numbers and a limited set of special symbols namely (- _ : .).

Additionally, the context is stored in our database with the exclamation mark, and we aim to remove it.

**backwards compatibility**
slack conversation about it: https://transifex.slack.com/archives/C01BHGRAGH1/p1693309705338759

How to test
-----------
Upload a YML i18n and a YAML_GENERIC resource file that includes custom tags featuring numbers or special symbols.

```yaml
en:
  context_string: !he:fd94_fd-la. "context string"
  verbim_context_string: !<!context545qa> "verbim context string"
  context_on_nested_map:
    first: !first_context:54KJFLA95KJ4 "context in nested map"
    second: !second_context:FDKJ40DK "context in nested map"
```

We expect these contextes:

string key | context
-- | --
context_string | he:fd94_fd-la.
verbim_context_string | context545qa
context_on_nested_map.first | first_context:54KJFLA95KJ4
context_on_nested_map.second | second_context:FDKJ40DK



We expect a downloaded file for the source language like this:
```yaml
en:
  context_string: !he:fd94_fd-la. "context string"
  verbim_context_string: !context545qa "verbim context string"
  context_on_nested_map:
    first: !first_context:54KJFLA95KJ4 "context in nested map"
    second: !second_context:FDKJ40DK "context in nested map"
```

We expect for the translation language a file like this: 
```yaml
el:
  context_string: !he:fd94_fd-la. ""
  verbim_context_string: !contex545qa ""
  context_on_nested_map:
    first: !first_context:54KJFLA95KJ4 ""
    second: !second_context:FDKJ40DK ""
    
```

**Staging**: https://yamlcntxt.stg.transifex.net/

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
