### PR TITLE
TX-15026: Downgrade lxml from 4.9.1 to 4.6.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mistune==0.7.3
 polib==1.0.3
 pyparsing==2.2.0
 six
-lxml==4.9.1
+lxml==4.6.5
 beautifulsoup4==4.9.3
 
 # InDesign

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     "mistune==0.7.3",
     "PyYAML==5.4.1",
     "pyparsing==2.2.0",
-    "lxml==4.9.1",
+    "lxml==4.6.5",
     "beautifulsoup4==4.9.3",
     "ucflib @ git+https://github.com/kbairak/ucflib.git@py3_compatibility#egg=ucflib-0.2.1",  # noqa
 ]


### PR DESCRIPTION
Downgrade lxml from 4.9.1 to 4.6.5

- 4.9.1 is probably unsafe, as it introduces a test-failure in TXC
- 4.6.5 fixes the HIGH & MEDIUM vulnerabilities reported without introducing any breaking changes 

 
<details>
<summary>Issue with v4.9.1 on TXC</summary>

```python
FAIL: test_namespace (tests.resources.lib.test_html2.TestHtmlHandler2)

Traceback (most recent call last):

  File "/usr/app/tests/resources/lib/test_html2.py", line 51, in test_namespace

    self.assertEquals(compiled_template.content, fragment)

AssertionError: '<html><body><bar>hello</bar></body></html>\n' != '<html><body><foo:bar>hello</foo:bar></body></html>\n'

- <html><body><bar>hello</bar></body></html>

+ <html><body><foo:bar>hello</foo:bar></body></html>

?              ++++           ++++
```
</details>

<details>

<summary>Changelog 4.6.2 (previous state) to 4.6.5</summary>
<p><em>Sourced from <a href="https://github.com/lxml/lxml/blob/master/CHANGES.txt">lxml's changelog</a>.</em></p>
<blockquote>

4.6.5 (2021-12-12)
==================

Bugs fixed
----------

* A vulnerability (GHSL-2021-1038) in the HTML cleaner allowed sneaking script
  content through SVG images (CVE-2021-43818).

* A vulnerability (GHSL-2021-1037) in the HTML cleaner allowed sneaking script
  content through CSS imports and other crafted constructs (CVE-2021-43818).


4.6.4 (2021-11-01)
==================

Features added
--------------

* GH#317: A new property ``system_url`` was added to DTD entities.
  Patch by Thirdegree.

* GH#314: The ``STATIC_*`` variables in ``setup.py`` can now be passed via env vars.
  Patch by Isaac Jurado.


4.6.3 (2021-03-21)
==================

Bugs fixed
----------

* A vulnerability (CVE-2021-28957) was discovered in the HTML Cleaner by Kevin Chung,
  which allowed JavaScript to pass through.  The cleaner now removes the HTML5
  ``formaction`` attribute.

</blockquote>
</summary>
</details>

TXC PR with v4.6.5 -> https://github.com/transifex/txc/pull/12046
APIv3 PR with v4.6.5 -> https://github.com/transifex/transifex-api-v3/pull/1096

