### PR TITLE
Fix Android XML format special characters escape/ unescape

### DIFF
--- a/openformats/formats/android_unescaped.py
+++ b/openformats/formats/android_unescaped.py
@@ -1,0 +1,29 @@
+from openformats.formats.android import AndroidHandler
+
+
+class AndroidUnescapedHandler(AndroidHandler):
+    @staticmethod
+    def escape(string):
+        string = AndroidHandler.escape(string)
+        return (
+            string.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+            .replace("@", "\\@")
+            .replace("?", "\\?")
+        )
+
+    @staticmethod
+    def unescape(string):
+        string = AndroidHandler.unescape(string)
+        return (
+            string.replace("\\?", "?")
+            .replace("\\@", "@")
+            .replace("\\t", "\t")
+            .replace("\\n", "\n")
+            .replace("&gt;", ">")
+            .replace("&lt;", "<")
+            .replace("&amp;", "&")
+        )

--- a/openformats/tests/formats/android/files/1_el.xml
+++ b/openformats/tests/formats/android/files/1_el.xml
@@ -3,6 +3,9 @@
     <!-- Testing simple string -->
     <string name="a_string">el:Simple string</string>
 
+    <!-- Testing string with special characters -->
+    <string name="b_string">el:Simple string &amp; \"with\" \'special characters\'</string>
+
     <!-- Testing with product attribute -->
     <string name="a_string" product="a_product">el:Simple string with product</string>
 

--- a/openformats/tests/formats/android/files/1_en.xml
+++ b/openformats/tests/formats/android/files/1_en.xml
@@ -3,6 +3,9 @@
     <!-- Testing simple string -->
     <string name="a_string">Simple string</string>
 
+    <!-- Testing string with special characters -->
+    <string name="b_string">Simple string &amp; \"with\" \'special characters\'</string>
+
     <!-- Testing with product attribute -->
     <string name="a_string" product="a_product">Simple string with product</string>
 

--- a/openformats/tests/formats/android/files/1_tpl.xml
+++ b/openformats/tests/formats/android/files/1_tpl.xml
@@ -3,6 +3,9 @@
     <!-- Testing simple string -->
     <string name="a_string">ac2562b9f825de04b7ae4736274b1e5f_tr</string>
 
+    <!-- Testing string with special characters -->
+    <string name="b_string">2cb7c4a9823431f0a9a4efc70603b465_tr</string>
+
     <!-- Testing with product attribute -->
     <string name="a_string" product="a_product">160db9c24b122af9e0f4218ad732d0ce_tr</string>
 

--- a/openformats/tests/formats/android/test_android_unescaped.py
+++ b/openformats/tests/formats/android/test_android_unescaped.py
@@ -1,0 +1,60 @@
+import unittest
+from openformats.formats.android_unescaped import AndroidUnescapedHandler
+from openformats.tests.formats.common import CommonFormatTestMixin
+from openformats.tests.utils.strings import (
+    generate_random_string,
+    strip_leading_spaces,
+    bytes_to_string,
+)
+
+from openformats.strings import OpenString
+
+
+class AndroidUnescapedTestCase(CommonFormatTestMixin, unittest.TestCase):
+    HANDLER_CLASS = AndroidUnescapedHandler
+    TESTFILE_BASE = "openformats/tests/formats/android/files"
+
+    def setUp(self):
+        super(AndroidUnescapedTestCase, self).setUp()
+        self.handler = AndroidUnescapedHandler()
+
+    def test_string(self):
+        random_key = generate_random_string()
+        random_string = generate_random_string()
+        random_openstring = OpenString(random_key, random_string, order=0)
+        random_hash = random_openstring.template_replacement
+
+        source_python_template = """
+            <resources>
+                <string name="{key}">{string}</string>
+            </resources>
+        """
+        source = source_python_template.format(key=random_key, string=random_string)
+
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [random_openstring])
+
+        self.assertEqual(
+            template, source_python_template.format(key=random_key, string=random_hash)
+        )
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__, random_openstring.__dict__)
+        self.assertEqual(compiled, source)
+
+    def test_escape(self):
+        rich = "&<>'\n\t@?" + '"'
+        raw = "&amp;&lt;&gt;\\'\\n\\t\\@\\?" + '\\"'
+
+        self.assertEqual(
+            AndroidUnescapedHandler.escape(rich),
+            raw,
+        )
+
+    def test_unescape(self):
+        rich = "&<>'\n\t@?" + '"'
+        raw = "&amp;&lt;&gt;\\'\\n\\t\\@\\?" + '\\"'
+
+        self.assertEqual(
+            AndroidUnescapedHandler.unescape(raw),
+            rich,
+        )


### PR DESCRIPTION
Problem and/or solution
-----------------------
Special characters like `&amp;` or `\n` remained unescape when importing the file, leading to be wrongly displayed in the editor


Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
