### PR TITLE
fix corrupted google sheet

### DIFF
--- a/openformats/formats/xlsx_unstructured.py
+++ b/openformats/formats/xlsx_unstructured.py
@@ -10,10 +10,21 @@ from uuid import uuid4
 from zipfile import ZipFile, ZIP_DEFLATED
 
 from bs4 import BeautifulSoup
+from bs4.dammit import EntitySubstitution
+from bs4.formatter import XMLFormatter
 
 from openformats.formats.office_open_xml.parser import OfficeOpenXmlHandler
 from openformats.handlers import Handler
 from openformats.strings import OpenString
+
+
+class UnsortedAttributes(XMLFormatter):
+    def __init__(self, *args, **kwargs):
+        super(XMLFormatter, self).__init__(entity_substitution=lambda string: EntitySubstitution.substitute_xml(string).replace('"', '&quot;'))
+
+    def attributes(self, tag):
+        for k, v in tag.attrs.items():
+            yield k, v
 
 
 def get_rels_path(sheet_path):
@@ -141,7 +152,7 @@ class XlsxFile(object):
 
     def set_workbook_content(self, content):
         with open(self.get_workbook_path(), "w") as f:
-            f.write(content)
+            f.write(content.encode(formatter=UnsortedAttributes()).decode())
 
     def get_sheet_content(self, sheet):
         with open(self.get_sheet(sheet)["path"], "r") as f:
@@ -150,7 +161,7 @@ class XlsxFile(object):
 
     def set_sheet_content(self, sheet, content):
         with open(self.get_sheet(sheet)["path"], "w") as f:
-            f.write(content)
+            f.write(content.encode(formatter=UnsortedAttributes()).decode())
 
     def has_rels(self, sheet):
         return os.path.exists(self.get_sheet(sheet)["rels_path"])
@@ -162,7 +173,7 @@ class XlsxFile(object):
 
     def set_sheet_rels_content(self, sheet, content):
         with open(self.get_sheet(sheet)["rels_path"], "w") as f:
-            f.write(content)
+            f.write(content.encode(formatter=UnsortedAttributes()).decode())
 
     def get_shared_strings_content(self):
         with open(self.get_shared_strings_path(), "r") as f:
@@ -171,7 +182,7 @@ class XlsxFile(object):
 
     def set_shared_strings_content(self, content):
         with open(self.get_shared_strings_path(), "w") as f:
-            f.write(content)
+            f.write(content.encode(formatter=UnsortedAttributes()).decode())
 
     def delete(self):
         shutil.rmtree(self.__tmp_folder)
@@ -215,7 +226,7 @@ class XlsxUnstructuredHandler(Handler, OfficeOpenXmlHandler):
             )
             sheet.attrs['txid'] = open_string.string_hash
             sheet_names.append(open_string)
-        xlsx.set_workbook_content(str(wordbook_soup))
+        xlsx.set_workbook_content(wordbook_soup)
         return sheet_names
 
     def parse(self, content, **kwargs):
@@ -338,8 +349,8 @@ class XlsxUnstructuredHandler(Handler, OfficeOpenXmlHandler):
                     elif sheet_name not in extracted_strings[string]["sheets"]:
                         extracted_strings[string]["sheets"].append(sheet_name)
 
-            xlsx.set_sheet_content(sheet, str(sheet_soup))
-        xlsx.set_shared_strings_content(str(shared_strings_soup))
+            xlsx.set_sheet_content(sheet, sheet_soup)
+        xlsx.set_shared_strings_content(shared_strings_soup)
 
         all_strings = []
 
@@ -399,7 +410,7 @@ class XlsxUnstructuredHandler(Handler, OfficeOpenXmlHandler):
 
             sheet.attrs["name"] = open_string.string
             sheet.attrs.pop("txid", None)
-        xlsx.set_workbook_content(str(workbook_soup))
+        xlsx.set_workbook_content(workbook_soup)
 
 
     def compile(self, template, stringset, **kwargs):
@@ -543,10 +554,10 @@ class XlsxUnstructuredHandler(Handler, OfficeOpenXmlHandler):
                             continue
                         t_string.string = translation
                 replace_string_to.attrs.pop("txid", None)
-            xlsx.set_sheet_content(sheet, str(sheet_soup))
-            xlsx.set_shared_strings_content(str(shared_strings_soup))
+            xlsx.set_sheet_content(sheet, sheet_soup)
+            xlsx.set_shared_strings_content(shared_strings_soup)
             if xlsx.has_rels(sheet):
-                xlsx.set_sheet_rels_content(sheet, str(sheet_rels_soup))
+                xlsx.set_sheet_rels_content(sheet, sheet_rels_soup)
 
         result = xlsx.compress()
         xlsx.delete()

--- a/openformats/formats/xlsx_unstructured.py
+++ b/openformats/formats/xlsx_unstructured.py
@@ -550,7 +550,7 @@ class XlsxUnstructuredHandler(Handler, OfficeOpenXmlHandler):
                         )
 
                         if not translation:
-                            t_string.decompose()
+                            t_string.string = ""
                             continue
                         t_string.string = translation
                 replace_string_to.attrs.pop("txid", None)

--- a/openformats/tests/formats/xlsx_unstructured/test_xlsx_unstructured.py
+++ b/openformats/tests/formats/xlsx_unstructured/test_xlsx_unstructured.py
@@ -317,7 +317,8 @@ class XlsxTestCase(unittest.TestCase):
         template, stringset = xlsx_handler.parse(compiled_file)
 
         self.assert_open_string(
-            stringset[6], {"string_hash": mock.ANY, "string": "no_tags"}
+            stringset[6],
+            {"string_hash": mock.ANY, "string": "<tx>no_tags</tx><tx></tx>"},
         )
 
     def test_extract_compile_hyperlink_formulas(self):


### PR DESCRIPTION
Problem and/or solution
-----------------------

When we compile an xlsx we should not decomponese a t tag (but we should set it to empty string)
The reason is that if we remove the <t> tag we should also remove the related <rPr> otherwise gsheets cannot open the sheet.

this is an example of a valid string object in sharedStrings.xml
```
    <si>
        <r>
            <rPr>
                <rFont val="Open Sans" />
                <b />
                <color theme="1" />
            </rPr>
            <t xml:space="preserve"></t>
        </r>
        <r>
            <rPr>
                <rFont val="Open Sans" />
                <b />
                <color theme="1" />
            </rPr>
            <t xml:space="preserve">string2</t>
        </r>
    </si>
````
when we parse the string we
1) extract non empty <t> elements 
2) wrap the strings in <tx></tx> tags to preserve formatting and return the result without adding unused empty tags
3) when we compile the document we remove add replace the translated strings to the first non empty <t> tags instead

before when we replacing the translation parts we were decomposing (destruct) the <t> tags which was leaving garbage like
```
<si>
        <r>
            <rPr>
                <rFont val="Open Sans" />
                <b />
                <color theme="1" />
            </rPr>
            <t xml:space="preserve">string2</t>
        </r>
        <r>
            <rPr>
                <rFont val="Open Sans" />
                <b />
                <color theme="1" />
            </rPr>
        </r>
    </si>
```
the above is invalid for google sheets
the valid alternatives are either
1) remove the whole <r> element or 
2) simply set the <t> tag string to an empty string

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
