### PR TITLE
Allow unescaped new lines when parsing Android XML files

### DIFF
--- a/openformats/formats/android_unescaped.py
+++ b/openformats/formats/android_unescaped.py
@@ -94,7 +94,6 @@ class AndroidUnescapedHandler(AndroidHandler):
             r'(?<!\\)"',
             r"(?<!\\)@",
             r"(?<!\\)\?",
-            r"(?<!\\)\n",
             r"(?<!\\)\t",
         ]
 

--- a/openformats/tests/formats/android/test_android_unescaped.py
+++ b/openformats/tests/formats/android/test_android_unescaped.py
@@ -20,6 +20,31 @@ class AndroidUnescapedTestCase(CommonFormatTestMixin, unittest.TestCase):
         super(AndroidUnescapedTestCase, self).setUp()
         self.handler = AndroidUnescapedHandler()
 
+
+
+    def test_allow_new_line_unescaped(self):
+        self.maxDiff = None
+        random_key = generate_random_string()
+        uploaded_string ='''Free 
+                    crypto
+                    '''
+        
+        uploaded_openstring = OpenString(random_key, uploaded_string, order=0)
+        uploaded_hash = uploaded_openstring.template_replacement
+
+        source_python_template = """
+            <resources>
+                <string name="{key}">{string}</string>
+            </resources>
+        """
+        source = source_python_template.format(key=random_key, string=uploaded_string)
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, [uploaded_openstring])
+        self.assertEqual(
+            template,
+            source_python_template.format(key=random_key, string=uploaded_hash),
+        )
+        self.assertEqual(compiled, source)
     def test_string(self):
         self.maxDiff = None
         random_key = generate_random_string()
@@ -87,12 +112,7 @@ class AndroidUnescapedTestCase(CommonFormatTestMixin, unittest.TestCase):
             AndroidUnescapedHandler._check_unescaped_characters,
             unescaped_string,
         )
-        unescaped_string = "some \n string"
-        self.assertRaises(
-            ParseError,
-            AndroidUnescapedHandler._check_unescaped_characters,
-            unescaped_string,
-        )
+       
         unescaped_string = "some \t string"
         self.assertRaises(
             ParseError,


### PR DESCRIPTION
Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
