### PR TITLE
Accept newlines and tabs in android v3

### DIFF
--- a/openformats/tests/formats/android/test_android_unescaped.py
+++ b/openformats/tests/formats/android/test_android_unescaped.py
@@ -87,15 +87,3 @@ class AndroidUnescapedTestCase(CommonFormatTestMixin, unittest.TestCase):
             AndroidUnescapedHandler._check_unescaped_characters,
             unescaped_string,
         )
-        unescaped_string = "some \n string"
-        self.assertRaises(
-            ParseError,
-            AndroidUnescapedHandler._check_unescaped_characters,
-            unescaped_string,
-        )
-        unescaped_string = "some \t string"
-        self.assertRaises(
-            ParseError,
-            AndroidUnescapedHandler._check_unescaped_characters,
-            unescaped_string,
-        )


### PR DESCRIPTION
Problem and/or solution
-----------------------

Some previous improvements were a bit overzealous. We were supposed to reject some characters that are not supported by Android and/or XML. We rejected newline and tab characters along with this. This created problems for the customer since the Android SDK tools accept newline characters in the strings

How to test
-----------

Set up transifex to use this parser and upload this file:

```xml
<resources>
   <string name="with newline">
        Free crypto
    </string>
    <string name="with escaped newline">Free \n crypto</string>
</resources>
```

Both uploads should work.

The first string should appear like this in the editor in rich mode:

![image](https://github.com/transifex/openformats/assets/1336464/9f2fc343-e7c4-4268-8300-702188c680c6)

and like this in raw mode:

![image](https://github.com/transifex/openformats/assets/1336464/943b8a6b-7597-4475-bfe7-ec3049be1223)

And the second string should look like this in rich mode:

![image](https://github.com/transifex/openformats/assets/1336464/3a5f6e68-25b6-433e-8341-ee34e1bd1bb8)

and like this in raw mode:

![image](https://github.com/transifex/openformats/assets/1336464/b343f3c7-c3db-4420-8d45-4d5cff1fbf33)


Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
