### PR TITLE
Adding support for ARB (Application Resource Bundle) (.arb) format

### DIFF
--- a/bin/create_files.py
+++ b/bin/create_files.py
@@ -32,6 +32,7 @@ def get_handler(ext):
         'vtt': vtt.VttHandler(),
         'xml': android.AndroidHandler(),
         'json': json.JsonHandler(),
+        'arb': json.ArbHandler(),
         'po': po.PoHandler(),
         'md': github_markdown_v2.GithubMarkdownHandlerV2(),
     }[ext]

--- a/openformats/formats/json.py
+++ b/openformats/formats/json.py
@@ -74,7 +74,7 @@ class JsonHandler(Handler):
             for key, key_position, value, value_position in parsed:
                 key = self._escape_key(key)
                 if nest is not None:
-                    key = u"{}.{}".format(nest, key)
+                    key = f"{nest}.{key}"
 
                 # 'key' should be unique
                 if key in self.existing_keys:
@@ -130,9 +130,9 @@ class JsonHandler(Handler):
         elif parsed.type == list:
             for index, (item, item_position) in enumerate(parsed):
                 if nest is None:
-                    key = u"..{}..".format(index)
+                    key = f"..{index}.."
                 else:
-                    key = u"{}..{}..".format(nest, index)
+                    key = f"{nest}..{index}.."
                 if isinstance(item, (six.binary_type, six.text_type)):
                     if not item.strip():
                         continue
@@ -162,7 +162,7 @@ class JsonHandler(Handler):
         # e.g. a pluralized string.
         # If it cannot be parsed that way (returns None), parse it like
         # a regular string.
-        parser = ICUParser(allow_numeric_plural_values=False)
+        parser = ICUParser(allow_numeric_plural_values = (self.name == "ARB"))
         icu_string = parser.parse(key, value)
         if icu_string:
             return self._create_pluralized_string(icu_string, value_position)
@@ -472,6 +472,123 @@ class JsonHandler(Handler):
         return unescape(string)
 
 
+class ArbHandler(JsonHandler):
+    name = "ARB"
+    extension = "arb"
+    keep_sections = True
+
+    def parse(self, content, **kwargs):
+        # Validate that content is JSON
+        self.validate_content(content)
+
+        self.transcriber = Transcriber(content)
+        source = self.transcriber.source
+        self.stringset = []
+        self.existing_keys = set()
+
+        try:
+            parsed = DumbJson(source)
+        except ValueError as e:
+            raise ParseError(six.text_type(e))
+        self._order = count()
+        self._find_keys(parsed)
+        self._extract(parsed)
+
+        if not self.stringset:
+            raise ParseError('No strings could be extracted')
+
+        self.transcriber.copy_until(len(source))
+
+        return self.transcriber.get_destination(), self.stringset
+
+    def _find_keys(self, parsed, nest=None):
+        if parsed.type == dict:
+            for key, key_position, value, _ in parsed:
+                key = self._escape_key(key)
+                if nest is not None:
+                    key = f"{nest}.{key}"
+
+                # 'key' should be unique
+                if key in self.existing_keys:
+                    # Need this for line number
+                    self.transcriber.copy_until(key_position)
+                    raise ParseError(u"Duplicate string key ('{}') in line {}".
+                                     format(key, self.transcriber.line_number))
+                if nest is None:  # store all root-level keys in order to detect duplication
+                    self.existing_keys.add(key)
+                elif key.startswith("@") and key.endswith(".type") and value != "text":
+                    self.existing_keys.add(key)
+
+                if isinstance(value, DumbJson):
+                    self._find_keys(value, key)
+                else:
+                    pass
+        else:
+            raise ParseError("Invalid JSON")
+
+    def _extract(self, parsed):
+        if parsed.type == dict:
+            # string_type = "text"
+            for key, _, value, value_position in parsed:
+                key = self._escape_key(key)
+
+                if key.startswith("@"):
+                    continue
+                elif isinstance(value, (six.text_type)):
+                    if not value.strip():
+                        continue
+                    elif f"@{key}.type" in self.existing_keys:
+                        continue
+
+                    openstring = self._create_openstring(key, value,
+                                                         value_position)
+                    if openstring:
+                        self.stringset.append(openstring)
+                else:
+                    # Ignore other JSON types (bools, nulls, numbers)
+                    pass
+        else:
+            raise ParseError("Invalid JSON")
+
+    def compile(self, template, stringset, **kwargs):
+        # Lets play on the template first, we need it to not include the hashes
+        # that aren't in the stringset. For that we will create a new stringset
+        # which will have the hashes themselves as strings and compile against
+        # that. The compilation process will remove any string sections that
+        # are absent from the stringset. Next we will call `_clean_empties`
+        # from the template to clear out any `...,  ,...` or `...{ ,...`
+        # sequences left. The result will be used as the actual template for
+        # the compilation process
+        self.keep_sections = kwargs.get('keep_sections', True)
+
+        stringset = list(stringset)
+
+        fake_stringset = [
+            OpenString(openstring.key,
+                    openstring.template_replacement,
+                    order=openstring.order,
+                    pluralized=openstring.pluralized)
+            for openstring in stringset
+        ]
+        new_template = self._replace_translations(
+            template, fake_stringset, False
+        )
+        new_template = self._clean_empties(new_template)
+
+        return self._replace_translations(new_template, stringset, True)
+
+    def _copy_until_and_remove_section(self, pos):
+        """
+        Copy characters to the transcriber until the given position,
+        then end the current section.
+        """
+        self.transcriber.copy_until(pos)
+        self.transcriber.mark_section_end()
+        # Unlike the JSON format, do not remove the remaining section of the template
+        if self.keep_sections == False:  # needed for a test
+            self.transcriber.remove_section()
+
+
 class StructuredJsonHandler(JsonHandler):
     """Handler that preserves certain keys for internal usage, while
     keeping the flexibility and functionality of the original JsonHandler. It
@@ -534,16 +651,15 @@ class StructuredJsonHandler(JsonHandler):
                 self.transcriber.add(u"null")
             else:
                 if template_value is None:
-                    self.transcriber.add(u"\"{}\"".format(value))
+                    self.transcriber.add(f"\"{value}\"")
                 else:
-                    self.transcriber.add(u"{}".format(value))
+                    self.transcriber.add(f"{value}")
         else:
             self.transcriber.add(u"null")
 
-        self.transcriber.skip(len(u"{}".format(template_value)))
+        self.transcriber.skip(len(f"{template_value}"))
         self.transcriber.copy_until(value_position +
-                                    len(u"{}".format(template_value)) +
-                                    1)
+                                    len(f"{template_value}") + 1)
 
     def _compile_recursively(self, current_part):
         if isinstance(current_part, DumbJson):
@@ -623,7 +739,7 @@ class StructuredJsonHandler(JsonHandler):
                                                 value_position)
                         elif not isinstance(value, DumbJson):
                             self.transcriber.copy_until(
-                                value_position + len(u"{}".format(value)) + 1
+                                value_position + len(f"{value}") + 1
                             )
 
                     extra_elements = []
@@ -765,7 +881,7 @@ class StructuredJsonHandler(JsonHandler):
         """
         # We need to parse only STRING_KEY keys, otherwise we should
         # early return
-        if not key.endswith(".{}".format(self.STRING_KEY)):
+        if not key.endswith(f".{self.STRING_KEY}"):
             return None
         # Remove the STRING_KEY part of the key as it is not needed. Add +1
         # when calculating the length of the STRING_KEY, for the "." character
@@ -1004,8 +1120,7 @@ class ChromeI18nHandlerV3(Handler):
              outer_key_position, outer_value, outer_value_position) in parsed:
             if outer_key in existing_keys:
                 transcriber.copy_until(outer_key_position)
-                raise ParseError(u"Key '{}' appears multiple times (line {})".
-                                 format(outer_key, transcriber.line_number))
+                raise ParseError(f"Key '{outer_key}' appears multiple times (line {transcriber.line_number})")
             existing_keys.add(outer_key)
 
             if not isinstance(outer_value, DumbJson):

--- a/openformats/tests/formats/arb/files/1_el.arb
+++ b/openformats/tests/formats/arb/files/1_el.arb
@@ -1,0 +1,43 @@
+{
+  "@@locale": "en_US",
+  "@@x-template": "path/to/template.arb",
+  "@@context": "HomePage",
+
+  "MSG_OK": "el:Everything works fine.",
+
+  "title_bar": "el:My Cool Home",
+  "@title_bar": {
+    "type": "text",
+    "context": "HomePage",
+    "description": "Page title."
+  },
+
+  "total_files": "{ item_count, plural, one {el:You have {file_count} file.} other {el:You have {file_count} files.} }",
+  "special_chars": "{ cnt, plural, one {el:This is Sam's book.} other {el:These are Sam's books.} }",
+  "gold_coins": "{count, plural, zero {el:The chest is empty.} one {el:You have one gold coin.} other {el:You have {cnt} gold coins.}}",
+  "custom_plural_value": "{number, plural, one {el:1 New} two {el:# New}}",
+
+  "logo@src": "images/001.jpg",
+  "@logo@src": {
+      "context": "arb_editor",
+      "type": "image",
+      "description": "logo image, 128x128"
+  },
+
+  "font_style": "#title {font-family: Verdana, Geneva, sans-serif; font-style: oblique; font-size: 36px}",
+  "@font_style": {
+      "context": "arb_editor",
+      "type": "css",
+      "description": "font specific css"
+  },
+
+  "input_test1@placeholder": "el:localized placeholder text",
+  "input_test2@value": "el:localized input value",
+
+  "logo": "el:ARB",
+  "@logo": {
+    "type": "text",
+    "screen": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBhQGBRUIBwgKFQkKDRYODRYMFhYfHhoWHRweHB8cHh4cJzIqIyUkHB4cITssLycpLCwsFSExPjAtNSgrLEABCQoKDQsNGQ4OGTUkHiQ1LDU1NS4sLCo1NTYpNTYpLCw1NS40NCw0LikuKSkpLCwpLCw0KTQpKSwsNCkpNCkpLP/AABEIADIAMgMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAABQIEBgcBA//EADQQAAEDAgIIAwUJAAAAAAAAAAEAAgMEEQUhBhITMUFRYXEUIjIjgbHB0QcWNEJTkaGi4f/EABgBAAMBAQAAAAAAAAAAAAAAAAABBAUC/8QAIBEAAgEEAgMBAAAAAAAAAAAAAAECAxExQQQhEiKhFP/aAAwDAQACEQMRAD8A7c30+4LN6WSubVwxxyPbYufdhIzyA3dyvtJjTqHFjHKWvpZbOjLbXFsiLjI2cDlvzVPSmobII6mJwLQ19rcxY2PLsmVUINVFddFj7xeGwNz5zeoiadU88sj9f9SfB8VqKOQvmqHSMkiHllPpflmCM7b7hIJ6uSplAkn9kDrFthY24Gwum9LXtqachoIeBmD8QeKWDS/PCEX0nf4OsG0hkmxjYVjmmOa4ZqgDVIBPcg9ei1Nlh8FDY8VbNM6zIgXn9rD+Sr2JaXPjkEVBTN13uDI9oTck7hYfVMhrUPKfotGrQq8DX+HbtpGbXVGvqjK9s7e9epEVjn+k8UmB4trAu8FUv2sd9weR5gOR49R2VeWsGI0oEbgJb2IPG+S6NV0TK+jNPVRNdE8WcHLn+O6DzUFUZMHa99M4ekWLmnkQSLjrv+KT6NCjyY+KUumtmbnqNhUGF5Ie02IKvUkxEJlYPLexKli2D1FDRNrcSpYtj6Ha4zHImxNhwGe9JjWSOpCwgiFxvEQ02yyIHPuk6mmiyNeMkOZMW1W2a4342TvQzAXYhiLcYqmkQwkmC/5iQRcdBc58Sk+iNBTmU1OkNXFZpAhidffzNt/AAZ9eS6w1oa2zQAAMrLq60S8nkNJwis7JoQhBmEW+kdgpWUW+kdgpIAyv2iR+I0dbSkfiayCP+4PyT+sw2PEaXYVdOx0Rys4fDkkOlz9pjNDSfq120PZgv81qBuSWzlN3Yjw/Q6mwup29NS+1YbtL3OdY8wHGwPVPEL1M7cnLLBCEIERb6R2CkhCAKlTA2Sdkj42F8TzsyQLt8h3HgrQQhAlk9QhCBghCEAf/2Q==",
+    "video": "http://www.youtube.com/user_interaction"
+  }
+}

--- a/openformats/tests/formats/arb/files/1_en.arb
+++ b/openformats/tests/formats/arb/files/1_en.arb
@@ -1,0 +1,43 @@
+{
+  "@@locale": "en_US",
+  "@@x-template": "path/to/template.arb",
+  "@@context": "HomePage",
+
+  "MSG_OK": "Everything works fine.",
+
+  "title_bar": "My Cool Home",
+  "@title_bar": {
+    "type": "text",
+    "context": "HomePage",
+    "description": "Page title."
+  },
+
+  "total_files": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
+  "special_chars": "{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }",
+  "gold_coins": "{count, plural, zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.}}",
+  "custom_plural_value": "{number, plural, =1 {1 New} =2 {# New}}",
+
+  "logo@src": "images/001.jpg",
+  "@logo@src": {
+      "context": "arb_editor",
+      "type": "image",
+      "description": "logo image, 128x128"
+  },
+
+  "font_style": "#title {font-family: Verdana, Geneva, sans-serif; font-style: oblique; font-size: 36px}",
+  "@font_style": {
+      "context": "arb_editor",
+      "type": "css",
+      "description": "font specific css"
+  },
+
+  "input_test1@placeholder": "localized placeholder text",
+  "input_test2@value": "localized input value",
+
+  "logo": "ARB",
+  "@logo": {
+    "type": "text",
+    "screen": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBhQGBRUIBwgKFQkKDRYODRYMFhYfHhoWHRweHB8cHh4cJzIqIyUkHB4cITssLycpLCwsFSExPjAtNSgrLEABCQoKDQsNGQ4OGTUkHiQ1LDU1NS4sLCo1NTYpNTYpLCw1NS40NCw0LikuKSkpLCwpLCw0KTQpKSwsNCkpNCkpLP/AABEIADIAMgMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAABQIEBgcBA//EADQQAAEDAgIIAwUJAAAAAAAAAAEAAgMEEQUhBhITMUFRYXEUIjIjgbHB0QcWNEJTkaGi4f/EABgBAAMBAQAAAAAAAAAAAAAAAAABBAUC/8QAIBEAAgEEAgMBAAAAAAAAAAAAAAECAxExQQQhEiKhFP/aAAwDAQACEQMRAD8A7c30+4LN6WSubVwxxyPbYufdhIzyA3dyvtJjTqHFjHKWvpZbOjLbXFsiLjI2cDlvzVPSmobII6mJwLQ19rcxY2PLsmVUINVFddFj7xeGwNz5zeoiadU88sj9f9SfB8VqKOQvmqHSMkiHllPpflmCM7b7hIJ6uSplAkn9kDrFthY24Gwum9LXtqachoIeBmD8QeKWDS/PCEX0nf4OsG0hkmxjYVjmmOa4ZqgDVIBPcg9ei1Nlh8FDY8VbNM6zIgXn9rD+Sr2JaXPjkEVBTN13uDI9oTck7hYfVMhrUPKfotGrQq8DX+HbtpGbXVGvqjK9s7e9epEVjn+k8UmB4trAu8FUv2sd9weR5gOR49R2VeWsGI0oEbgJb2IPG+S6NV0TK+jNPVRNdE8WcHLn+O6DzUFUZMHa99M4ekWLmnkQSLjrv+KT6NCjyY+KUumtmbnqNhUGF5Ie02IKvUkxEJlYPLexKli2D1FDRNrcSpYtj6Ha4zHImxNhwGe9JjWSOpCwgiFxvEQ02yyIHPuk6mmiyNeMkOZMW1W2a4342TvQzAXYhiLcYqmkQwkmC/5iQRcdBc58Sk+iNBTmU1OkNXFZpAhidffzNt/AAZ9eS6w1oa2zQAAMrLq60S8nkNJwis7JoQhBmEW+kdgpWUW+kdgpIAyv2iR+I0dbSkfiayCP+4PyT+sw2PEaXYVdOx0Rys4fDkkOlz9pjNDSfq120PZgv81qBuSWzlN3Yjw/Q6mwup29NS+1YbtL3OdY8wHGwPVPEL1M7cnLLBCEIERb6R2CkhCAKlTA2Sdkj42F8TzsyQLt8h3HgrQQhAlk9QhCBghCEAf/2Q==",
+    "video": "http://www.youtube.com/user_interaction"
+  }
+}

--- a/openformats/tests/formats/arb/files/1_en_exported.arb
+++ b/openformats/tests/formats/arb/files/1_en_exported.arb
@@ -1,0 +1,43 @@
+{
+  "@@locale": "en_US",
+  "@@x-template": "path/to/template.arb",
+  "@@context": "HomePage",
+
+  "MSG_OK": "Everything works fine.",
+
+  "title_bar": "My Cool Home",
+  "@title_bar": {
+    "type": "text",
+    "context": "HomePage",
+    "description": "Page title."
+  },
+
+  "total_files": "{ item_count, plural, one {You have {file_count} file.} other {You have {file_count} files.} }",
+  "special_chars": "{ cnt, plural, one {This is Sam's book.} other {These are Sam's books.} }",
+  "gold_coins": "{count, plural, zero {The chest is empty.} one {You have one gold coin.} other {You have {cnt} gold coins.}}",
+  "custom_plural_value": "{number, plural, one {1 New} two {# New}}",
+
+  "logo@src": "images/001.jpg",
+  "@logo@src": {
+      "context": "arb_editor",
+      "type": "image",
+      "description": "logo image, 128x128"
+  },
+
+  "font_style": "#title {font-family: Verdana, Geneva, sans-serif; font-style: oblique; font-size: 36px}",
+  "@font_style": {
+      "context": "arb_editor",
+      "type": "css",
+      "description": "font specific css"
+  },
+
+  "input_test1@placeholder": "localized placeholder text",
+  "input_test2@value": "localized input value",
+
+  "logo": "ARB",
+  "@logo": {
+    "type": "text",
+    "screen": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBhQGBRUIBwgKFQkKDRYODRYMFhYfHhoWHRweHB8cHh4cJzIqIyUkHB4cITssLycpLCwsFSExPjAtNSgrLEABCQoKDQsNGQ4OGTUkHiQ1LDU1NS4sLCo1NTYpNTYpLCw1NS40NCw0LikuKSkpLCwpLCw0KTQpKSwsNCkpNCkpLP/AABEIADIAMgMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAABQIEBgcBA//EADQQAAEDAgIIAwUJAAAAAAAAAAEAAgMEEQUhBhITMUFRYXEUIjIjgbHB0QcWNEJTkaGi4f/EABgBAAMBAQAAAAAAAAAAAAAAAAABBAUC/8QAIBEAAgEEAgMBAAAAAAAAAAAAAAECAxExQQQhEiKhFP/aAAwDAQACEQMRAD8A7c30+4LN6WSubVwxxyPbYufdhIzyA3dyvtJjTqHFjHKWvpZbOjLbXFsiLjI2cDlvzVPSmobII6mJwLQ19rcxY2PLsmVUINVFddFj7xeGwNz5zeoiadU88sj9f9SfB8VqKOQvmqHSMkiHllPpflmCM7b7hIJ6uSplAkn9kDrFthY24Gwum9LXtqachoIeBmD8QeKWDS/PCEX0nf4OsG0hkmxjYVjmmOa4ZqgDVIBPcg9ei1Nlh8FDY8VbNM6zIgXn9rD+Sr2JaXPjkEVBTN13uDI9oTck7hYfVMhrUPKfotGrQq8DX+HbtpGbXVGvqjK9s7e9epEVjn+k8UmB4trAu8FUv2sd9weR5gOR49R2VeWsGI0oEbgJb2IPG+S6NV0TK+jNPVRNdE8WcHLn+O6DzUFUZMHa99M4ekWLmnkQSLjrv+KT6NCjyY+KUumtmbnqNhUGF5Ie02IKvUkxEJlYPLexKli2D1FDRNrcSpYtj6Ha4zHImxNhwGe9JjWSOpCwgiFxvEQ02yyIHPuk6mmiyNeMkOZMW1W2a4342TvQzAXYhiLcYqmkQwkmC/5iQRcdBc58Sk+iNBTmU1OkNXFZpAhidffzNt/AAZ9eS6w1oa2zQAAMrLq60S8nkNJwis7JoQhBmEW+kdgpWUW+kdgpIAyv2iR+I0dbSkfiayCP+4PyT+sw2PEaXYVdOx0Rys4fDkkOlz9pjNDSfq120PZgv81qBuSWzlN3Yjw/Q6mwup29NS+1YbtL3OdY8wHGwPVPEL1M7cnLLBCEIERb6R2CkhCAKlTA2Sdkj42F8TzsyQLt8h3HgrQQhAlk9QhCBghCEAf/2Q==",
+    "video": "http://www.youtube.com/user_interaction"
+  }
+}

--- a/openformats/tests/formats/arb/files/1_tpl.arb
+++ b/openformats/tests/formats/arb/files/1_tpl.arb
@@ -1,0 +1,43 @@
+{
+  "@@locale": "en_US",
+  "@@x-template": "path/to/template.arb",
+  "@@context": "HomePage",
+
+  "MSG_OK": "2c95ff04fb99537ccc47e9481b3a6c10_tr",
+
+  "title_bar": "f5fa68e97e4dc76f9ded7c1d71069822_tr",
+  "@title_bar": {
+    "type": "text",
+    "context": "HomePage",
+    "description": "Page title."
+  },
+
+  "total_files": "{ item_count, plural, 9af043f75968a7df63dfa2b27c57e2dc_pl }",
+  "special_chars": "{ cnt, plural, 00fe762ad9b56187fed536350bc3a40c_pl }",
+  "gold_coins": "{count, plural, 8060865280cf7fc9e80b79145208a825_pl}",
+  "custom_plural_value": "{number, plural, ee829fd77061d65f1f18982a577b915b_pl}",
+
+  "logo@src": "images/001.jpg",
+  "@logo@src": {
+      "context": "arb_editor",
+      "type": "image",
+      "description": "logo image, 128x128"
+  },
+
+  "font_style": "#title {font-family: Verdana, Geneva, sans-serif; font-style: oblique; font-size: 36px}",
+  "@font_style": {
+      "context": "arb_editor",
+      "type": "css",
+      "description": "font specific css"
+  },
+
+  "input_test1@placeholder": "2eff8610f5d585a18aa1df53391f9d90_tr",
+  "input_test2@value": "85d86301853ad1cf705881926cb0cc56_tr",
+
+  "logo": "fefbd77ea136fd8d6bcd5e6f8a4ef8e4_tr",
+  "@logo": {
+    "type": "text",
+    "screen": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBhQGBRUIBwgKFQkKDRYODRYMFhYfHhoWHRweHB8cHh4cJzIqIyUkHB4cITssLycpLCwsFSExPjAtNSgrLEABCQoKDQsNGQ4OGTUkHiQ1LDU1NS4sLCo1NTYpNTYpLCw1NS40NCw0LikuKSkpLCwpLCw0KTQpKSwsNCkpNCkpLP/AABEIADIAMgMBIgACEQEDEQH/xAAbAAACAwEBAQAAAAAAAAAAAAAABQIEBgcBA//EADQQAAEDAgIIAwUJAAAAAAAAAAEAAgMEEQUhBhITMUFRYXEUIjIjgbHB0QcWNEJTkaGi4f/EABgBAAMBAQAAAAAAAAAAAAAAAAABBAUC/8QAIBEAAgEEAgMBAAAAAAAAAAAAAAECAxExQQQhEiKhFP/aAAwDAQACEQMRAD8A7c30+4LN6WSubVwxxyPbYufdhIzyA3dyvtJjTqHFjHKWvpZbOjLbXFsiLjI2cDlvzVPSmobII6mJwLQ19rcxY2PLsmVUINVFddFj7xeGwNz5zeoiadU88sj9f9SfB8VqKOQvmqHSMkiHllPpflmCM7b7hIJ6uSplAkn9kDrFthY24Gwum9LXtqachoIeBmD8QeKWDS/PCEX0nf4OsG0hkmxjYVjmmOa4ZqgDVIBPcg9ei1Nlh8FDY8VbNM6zIgXn9rD+Sr2JaXPjkEVBTN13uDI9oTck7hYfVMhrUPKfotGrQq8DX+HbtpGbXVGvqjK9s7e9epEVjn+k8UmB4trAu8FUv2sd9weR5gOR49R2VeWsGI0oEbgJb2IPG+S6NV0TK+jNPVRNdE8WcHLn+O6DzUFUZMHa99M4ekWLmnkQSLjrv+KT6NCjyY+KUumtmbnqNhUGF5Ie02IKvUkxEJlYPLexKli2D1FDRNrcSpYtj6Ha4zHImxNhwGe9JjWSOpCwgiFxvEQ02yyIHPuk6mmiyNeMkOZMW1W2a4342TvQzAXYhiLcYqmkQwkmC/5iQRcdBc58Sk+iNBTmU1OkNXFZpAhidffzNt/AAZ9eS6w1oa2zQAAMrLq60S8nkNJwis7JoQhBmEW+kdgpWUW+kdgpIAyv2iR+I0dbSkfiayCP+4PyT+sw2PEaXYVdOx0Rys4fDkkOlz9pjNDSfq120PZgv81qBuSWzlN3Yjw/Q6mwup29NS+1YbtL3OdY8wHGwPVPEL1M7cnLLBCEIERb6R2CkhCAKlTA2Sdkj42F8TzsyQLt8h3HgrQQhAlk9QhCBghCEAf/2Q==",
+    "video": "http://www.youtube.com/user_interaction"
+  }
+}

--- a/openformats/tests/formats/arb/files/1_tpl.arb
+++ b/openformats/tests/formats/arb/files/1_tpl.arb
@@ -5,7 +5,7 @@
 
   "MSG_OK": "2c95ff04fb99537ccc47e9481b3a6c10_tr",
 
-  "title_bar": "f5fa68e97e4dc76f9ded7c1d71069822_tr",
+  "title_bar": "aaf0404af25d7a7ce4ccab203e70725f_tr",
   "@title_bar": {
     "type": "text",
     "context": "HomePage",

--- a/openformats/tests/formats/arb/test_arb.py
+++ b/openformats/tests/formats/arb/test_arb.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+
+from os import path
+import unittest
+
+import six
+
+from openformats.exceptions import ParseError
+from openformats.formats.json import ArbHandler
+from openformats.strings import OpenString
+from openformats.tests.formats.common import CommonFormatTestMixin
+from openformats.tests.utils.strings import (bytes_to_string,
+                                             generate_random_string)
+
+
+class ArbTestCase(CommonFormatTestMixin, unittest.TestCase):
+
+    HANDLER_CLASS = ArbHandler
+    TESTFILE_BASE = "openformats/tests/formats/arb/files"
+
+    def setUp(self):
+        super(ArbTestCase, self).setUp()
+        filepath = path.join(self.TESTFILE_BASE, "1_en_exported.arb")
+        with open(filepath, "r", encoding='utf-8') as myfile:
+            self.data['1_en_exported'] = myfile.read()
+
+        self.handler = ArbHandler()
+        self.random_string = generate_random_string()
+        self.random_openstring = OpenString("a", self.random_string, order=0)
+        self.random_hash = self.random_openstring.template_replacement
+
+    def test_simple(self):
+        # Using old-timey string formatting because of conflicts with '{'
+        template, stringset = self.handler.parse('{"a": "%s"}' %
+                                                 self.random_string)
+        self.assertEqual(template, '{"a": "%s"}' % self.random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__,
+                         self.random_openstring.__dict__)
+
+        compiled = self.handler.compile(template, [self.random_openstring])
+        self.assertEqual(compiled, '{"a": "%s"}' % self.random_string)
+
+    def test_empty_string_ignored(self):
+        _, stringset = self.handler.parse(
+            '{"not_empty": "hello there", "empty": ""}'
+        )
+        self.assertEqual(len(stringset), 1)
+
+    def test_empty_string_returned_in_compile(self):
+        template, stringset = self.handler.parse('{"a": "%s", "b": ""}' %
+                                                 self.random_string)
+        compiled = self.handler.compile(template, [self.random_openstring])
+
+        self.assertEqual(template, '{"a": "%s", "b": ""}' % self.random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__,
+                         self.random_openstring.__dict__)
+        self.assertEqual(compiled, '{"a": "%s", "b": ""}' % self.random_string)
+
+    def test_compile(self):
+        """Test that import-export is the same as the original file."""
+        remade_orig_content = self.handler.compile(self.tmpl, self.strset)
+        self.assertEqual(remade_orig_content, self.data["1_en_exported"])
+
+    def test_compile_skips_removed_strings_for_dicts(self):
+        string1 = self.random_string
+        string2 = generate_random_string()
+        openstring1 = self.random_openstring
+        openstring2 = OpenString("b", string2, order=1)
+        hash1 = self.random_hash
+        hash2 = openstring2.template_replacement
+
+        source = '{"a": "%s", "b": "%s"}' % (string1, string2)
+        template, stringset = self.handler.parse(source)
+        self.assertEqual(template, '{"a": "%s", "b": "%s"}' % (hash1, hash2))
+        self.assertEqual(len(stringset), 2)
+        self.assertEqual(stringset[0].__dict__, openstring1.__dict__)
+        self.assertEqual(stringset[1].__dict__, openstring2.__dict__)
+
+        compiled = self.handler.compile(template, [openstring2], keep_sections=False)
+        compiled = compiled.replace("{ ", "{").replace(" }", "}")  # fix spaces inside {}
+        self.assertEqual(compiled, '{"b": "%s"}' % string2)
+
+    def test_whitespace_only_strings(self):
+        self._test_parse_error('{"a": " ", "b": "   "}',
+                               "No strings could be extracted")
+
+    def test_remove_all_strings_removed_from_dict_but_non_strings_exist(self):
+        random_string = self.random_string
+        random_openstring = self.random_openstring
+        random_hash = self.random_hash
+
+        source = '{"a": "%s", "b": null}' % random_string
+
+        template, stringset = self.handler.parse(source)
+        self.assertEqual(template, '{"a": "%s", "b": null}' % random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__, random_openstring.__dict__)
+
+        compiled = self.handler.compile(template, [], keep_sections=False)
+        self.assertEqual(compiled, '{ "b": null}')
+
+    def test_skip_start_of_dict(self):
+        string1 = self.random_string
+        string2 = generate_random_string()
+        openstring2 = OpenString('b', string2, order=1)
+
+        source = '{"a": "%s", "b": "%s"}' % (string1, string2)
+        template, _ = self.handler.parse(source)
+
+        compiled = self.handler.compile(template, [openstring2], keep_sections=False)
+        self.assertEqual(compiled, '{ "b": "%s"}' % string2)
+
+    def test_skip_end_of_dict(self):
+        string1 = self.random_string
+        string2 = generate_random_string()
+        openstring1 = OpenString('a', string1, order=1)
+
+        source = '{"a": "%s", "b": "%s"}' % (string1, string2)
+        template, _ = self.handler.parse(source)
+
+        compiled = self.handler.compile(template, [openstring1], keep_sections=False)
+        self.assertEqual(compiled, '{"a": "%s"}' % string1)
+
+    def test_skip_middle_of_dict(self):
+        string1 = self.random_string
+        string2 = generate_random_string()
+        string3 = generate_random_string()
+        openstring1 = OpenString('a', string1, order=0)
+        openstring3 = OpenString('c', string3, order=2)
+
+        source = '{"a": "%s", "b": "%s", "c": "%s"}' % (string1, string2,
+                                                        string3)
+        template, _ = self.handler.parse(source)
+
+        compiled = self.handler.compile(template, [openstring1, openstring3], keep_sections=False)
+        self.assertEqual(compiled, '{"a": "%s", "c": "%s"}' % (string1,
+                                                               string3))
+
+    def test_invalid_json(self):
+        try:
+            self.handler.parse(u'jaosjf')
+        except Exception as e:
+            self.assertIn(six.text_type(e),
+                          ("Expecting value: line 1 column 1 (char 0)",
+                           "No JSON object could be decoded"))
+        else:
+            raise AssertionError("No parse error raised")
+
+    def test_not_json_container(self):
+        self._test_parse_error('"hello"',
+                               'Was expecting whitespace or one of `[{` on line 1, found `"` instead')
+        self._test_parse_error('3',
+                               "Was expecting whitespace or one of `[{` on line 1, found `3` instead")
+        self._test_parse_error('false',
+                               "Was expecting whitespace or one of `[{` on line 1, found `f` instead")
+
+    def test_skipping_stuff_within_strings(self):
+        source = '{"a": "b,  ,c"}'
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, stringset)
+        self.assertEqual(compiled, source)
+
+    def test_duplicate_keys(self):
+        self._test_parse_error('{"a": "hello", "a": "world"}',
+                               "Duplicate string key ('a') in line 1")
+
+    def test_display_json_errors(self):
+        self._test_parse_error('["]',
+                               "Unterminated string starting at: line 1 "
+                               "column 2 (char 1)")
+
+    def test_unescape(self):
+        cases = (
+            # simple => simple
+            ([u's', u'i', u'm', u'p', u'l', u'e'],
+             [u's', u'i', u'm', u'p', u'l', u'e']),
+            # hεllo => hεllo
+            ([u'h', u'ε', u'l', u'l', u'o'],
+             [u'h', u'ε', u'l', u'l', u'o']),
+            # h\u03b5llo => hεllo
+            ([u'h', u'\\', u'u', u'0', u'3', u'b', u'5', u'l', u'l', u'o'],
+             [u'h', u'ε', u'l', u'l', u'o']),
+            # a\"b => a"b
+            ([u'a', u'\\', u'"', u'b'], [u'a', u'"', u'b']),
+            # a\/b => a/b
+            ([u'a', u'\\', u'/', u'b'], [u'a', u'/', u'b']),
+            # a\/b => a?b, ? = BACKSPACE
+            ([u'a', u'\\', u'b', u'b'], [u'a', u'\b', u'b']),
+            # a\fb => a?b, ? = FORMFEED
+            ([u'a', u'\\', u'f', u'b'], [u'a', u'\f', u'b']),
+            # a\nb => a?b, ? = NEWLINE
+            ([u'a', u'\\', u'n', u'b'], [u'a', u'\n', u'b']),
+            # a\rb => a?b, ? = CARRIAGE_RETURN
+            ([u'a', u'\\', u'r', u'b'], [u'a', u'\r', u'b']),
+            # a\tb => a?b, ? = TAB
+            ([u'a', u'\\', u't', u'b'], [u'a', u'\t', u'b']),
+        )
+        for raw, rich in cases:
+            self.assertEqual(ArbHandler.unescape(bytes_to_string(raw)),
+                             bytes_to_string(rich))
+
+    def test_escape(self):
+        cases = (
+            # simple => simple
+            ([u's', u'i', u'm', u'p', u'l', u'e'],
+             [u's', u'i', u'm', u'p', u'l', u'e']),
+            # hεllo => hεllo
+            ([u'h', u'ε', u'l', u'l', u'o'],
+             [u'h', u'ε', u'l', u'l', u'o']),
+            # h\u03b5llo => h\\u03b5llo
+            ([u'h', u'\\', u'u', u'0', u'3', u'b', u'5', u'l', u'l', u'o'],
+             [u'h', u'\\', u'\\', u'u', u'0', u'3', u'b', u'5', u'l', u'l',
+              u'o']),
+            # a"b =>a\"b
+            ([u'a', u'"', u'b'], [u'a', u'\\', u'"', u'b']),
+            # a/b =>a/b
+            ([u'a', u'/', u'b'], [u'a', u'/', u'b']),
+            # a?b =>a\/b, ? = BACKSPACE
+            ([u'a', u'\b', u'b'], [u'a', u'\\', u'b', u'b']),
+            # a?b =>a\fb, ? = FORMFEED
+            ([u'a', u'\f', u'b'], [u'a', u'\\', u'f', u'b']),
+            # a?b =>a\nb, ? = NEWLINE
+            ([u'a', u'\n', u'b'], [u'a', u'\\', u'n', u'b']),
+            # a?b =>a\rb, ? = CARRIAGE_RETURN
+            ([u'a', u'\r', u'b'], [u'a', u'\\', u'r', u'b']),
+            # a?b => a\tb, ? = TAB
+            ([u'a', u'\t', u'b'], [u'a', u'\\', u't', u'b']),
+        )
+        for rich, raw in cases:
+            self.assertEqual(ArbHandler.escape(bytes_to_string(rich)),
+                             bytes_to_string(raw))
+
+    # PLURALS
+
+    def test_invalid_plural_format(self):
+        # Test various cases of messed-up braces
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, one {You have {file_count file.} other {You have {file_count} files.} }" }',  # noqa
+            'Invalid format of pluralized entry with key: "total_files"'
+        )
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, one {You have file_count} file.} other {You have {file_count} files.} }" }',  # noqa
+            'Invalid format of pluralized entry with key: "total_files"'
+        )
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, one {You have {file_count} file. other {You have {file_count} files.} }" }',  # noqa
+            'Invalid format of pluralized entry with key: "total_files"'
+        )
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, one {You have {file_count} file}. other {You have file_count} files.} }" }',  # noqa
+            'Invalid format of pluralized entry with key: "total_files"'
+        )
+
+    def test_invalid_plural_rules(self):
+        # Only the following strings are allowed as plural rules:
+        #   zero, one, few, many, other
+        # Anything else, including their TX int equivalents are invalid.
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, 1 {file} 5 {{file_count} files} }" }',  # noqa
+            'Invalid plural rule(s): "1, 5" in pluralized entry with key: total_files'  # noqa
+        )
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, once {file} mother {{file_count} files} }" }',  # noqa
+            'Invalid plural rule(s): "once, mother" in pluralized entry with key: total_files'  # noqa
+        )
+        self._test_parse_error_message(
+            '{ "total_files": "{ item_count, plural, =3 {file} other {{file_count} files} }" }',  # noqa
+            'Invalid plural rule(s): "=3" in pluralized entry with key: total_files'  # noqa
+        )
+
+    def test_irrelevant_whitespace_ignored(self):
+        # Whitespace between the various parts of the message format structure
+        # should be ignored.
+        expected_translations = {0: 'Empty', 5: '{count} files'}
+
+        self._test_translations_equal(
+            '{'
+            '    "k": "{ cnt, plural, zero {Empty} other {{count} files} }"'
+            '}',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{'
+            '    "k": "{cnt,plural,zero{Empty}other{{count} files} }"'
+            '}',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{ "k": "{    cnt,  plural,     zero  {Empty} other   {{count} files} }   "     }',  # noqa
+            expected_translations
+        )
+        self._test_translations_equal(
+            '     {'
+            '    "k": "{cnt,plural,zero{Empty}other{{count} files} }"'
+            '}  ',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{'
+            '    "k": "  {cnt, plural, zero {Empty} other {{count} files} }"'
+            '}',
+            expected_translations
+        )
+        self._test_translations_equal(
+            '{'
+            '    "k": "{cnt , plural , zero {Empty} other {{count} files} }"'
+            '}',
+            expected_translations
+        )
+
+        # Escaped new lines should be allowed
+        self._test_translations_equal(
+            '{'
+            '    "k": "{cnt, plural,\\n zero {Empty} other {{count} files} \\n}"'  # noqa
+            '}',
+            expected_translations
+        )
+
+        # Rendering a template with escaped new lines should work. However,
+        # these characters cannot be inside the pluralized string, because the
+        # template would be very hard to create in that case (e.g. not allowed
+        # in: 'zero {Empty} \n other {{count} files}'
+        source = '{"a": "{cnt, plural,\\n one {0} other {{count} files} \\n}"}'
+        template, stringset = self.handler.parse(source)
+        compiled = self.handler.compile(template, stringset)
+        self.assertEqual(compiled, source)
+
+    def test_non_supported_icu_argument(self):
+        # Non-supported ICU arguments (everything other than `plural`)
+        # should make a string be treated as non-pluralized
+
+        string = '{"k": "{ gender_of_host, select, female {{host} appeared} male {{host} appeared} }"}'  # noqa
+        _, stringset = self.handler.parse(string)
+
+        self.assertEqual(
+            stringset[0].string,
+            '{ gender_of_host, select, female {{host} appeared} male {{host} appeared} }'  # noqa
+        )
+
+    def test_whitespace_in_translations_not_ignored(self):
+        # Whitespace between the various parts of the message format structure
+        # should be ignored.
+        self._test_translations_equal(
+            '{"k": "{ cnt, plural, zero { Empty} other {{count} files} }"}',
+            {0: ' Empty', 5: '{count} files'}
+        )
+        self._test_translations_equal(
+            '{"k": "{ cnt, plural, zero { Empty  } other {{count} files } }"}',
+            {0: ' Empty  ', 5: '{count} files '}
+        )
+
+    def _test_parse_error_message(self, source, msg_substr):
+        error_raised = False
+        try:
+            self.handler.parse(source)
+        except ParseError as e:
+            self.assertIn(msg_substr, six.text_type(e))
+            error_raised = True
+        self.assertTrue(error_raised)
+
+    def _test_translations_equal(self, source, translations_by_rule):
+        _, stringset = self.handler.parse(source)
+        for rule_int in six.iterkeys(translations_by_rule):
+            self.assertEqual(
+                translations_by_rule[rule_int],
+                stringset[0].string[rule_int]
+            )

--- a/openformats/tests/formats/arb/test_arb.py
+++ b/openformats/tests/formats/arb/test_arb.py
@@ -82,6 +82,20 @@ class ArbTestCase(CommonFormatTestMixin, unittest.TestCase):
         compiled = compiled.replace("{ ", "{").replace(" }", "}")  # fix spaces inside {}
         self.assertEqual(compiled, '{"b": "%s"}' % string2)
 
+    def test_locale(self):
+        source = '{"@@locale": "en_US", "a": "%s"}' % self.random_string
+        template, stringset = self.handler.parse(source)
+        self.assertEqual(template,
+                         '{"@@locale": "en_US", "a": "%s"}' % self.random_hash)
+        self.assertEqual(len(stringset), 1)
+        self.assertEqual(stringset[0].__dict__,
+                         self.random_openstring.__dict__)
+
+        compiled = self.handler.compile(template, [self.random_openstring],
+                                        language_info={"name": "French", "code": "fr"})
+        self.assertEqual(compiled,
+                         '{"@@locale": "fr", "a": "%s"}' % self.random_string)
+
     def test_whitespace_only_strings(self):
         self._test_parse_error('{"a": " ", "b": "   "}',
                                "No strings could be extracted")


### PR DESCRIPTION
Problem and/or solution
-----------------------
Adding parsing and compiling for ARB (Application Resource Bundle) (.arb) format

How to test
-----------
### 1. Running unit-tests
`/openformats/tests/formats/arb/test_arb.py` contains tests for arb
Use `pytest /openformats/tests/formats/arb/test_arb.py` to run tests

### 2. Through testbed
Use "ARB" handler in the testbed

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
