### PR TITLE
Android parser: Fix for escaping  character <

### DIFF
--- a/openformats/tests/formats/android/test_android_unescaped.py
+++ b/openformats/tests/formats/android/test_android_unescaped.py
@@ -53,6 +53,31 @@ class AndroidUnescapedTestCase(CommonFormatTestMixin, unittest.TestCase):
             raw,
         )
 
+    def test_escape_lt_character(self):
+        rich = '< 20 units'
+        raw = '&lt; 20 units'
+
+        self.assertEqual(
+            AndroidUnescapedHandler.escape(rich),
+            raw,
+        )
+
+        rich = '< 20 & > 50 units'
+        raw = '&lt; 20 &amp; &gt; 50 units'
+
+        self.assertEqual(
+            AndroidUnescapedHandler.escape(rich),
+            raw,
+        )
+
+        rich = '< 20 & > 50 units<xliff:g>test</xliff:g>'
+        raw = '&lt; 20 &amp; &gt; 50 units&lt;xliff:g&gt;test&lt;/xliff:g&gt;'
+
+        self.assertEqual(
+            AndroidUnescapedHandler.escape(rich),
+            raw,
+        )
+
     def test_unescape(self):
         rich = "&<>'\n\t@?" + '"'
         raw = "&amp;&lt;&gt;\\'\\n\\t\\@\\?" + '\\"'


### PR DESCRIPTION
Problem and/or solution
-----------------------
Currently, when calling AI/MT services to translate a string, we check if the resource supports raw formatting. If it does, we unescape the strings to ensure that "rich" mode is always passed to the AI/MT services. After receiving the translation, we escape the translated strings before storing them in the database.

However, for strings like` < 20 units`, the escape function fails due to a parsing error. Specifically, the Android parser tries to parse the uploaded content and detect inline protected tags, but this fails with an error indicating the absence of a closing `> `tag.

To address this, we can catch the exception during the parsing of inline tags and escape all special characters  the string. 

How to test
-----------
Source string => String in translations downloaded file
 '< 20 units'  =>  '&lt; 20 units'
 '< 20 & > 50 units<xliff:g>test</xliff:g>'' => the xlif protected tag is not respected in this case. Unfortunately, i was not able to find a solution to handle this case as well
       
Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
