### PR TITLE
Fix for Docx parser

### DIFF
--- a/openformats/formats/office_open_xml/parser.py
+++ b/openformats/formats/office_open_xml/parser.py
@@ -249,7 +249,7 @@ class OfficeOpenXmlHandler(object):
         # the text parts of the translation are more that the
         # text parts of the document, so we will compress the
         # remaining translation parts into one string
-        if len(translation_soup) > 0:
+        if len(translation_soup) > 0 and last_element and last_element.contents:
             translation = last_element.contents[0] + \
                           "".join([six.text_type(t) for t in translation_soup]
             )


### PR DESCRIPTION
Problem and/or solution
-----------------------

How to test
-----------

If last_element is None, an exception is thrown when we try to access last_elemetns.contents[0] and  template can not be compiled.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
