### PR TITLE
Remove BOM (Byte Order Mark) bytes

### DIFF
--- a/openformats/formats/docx.py
+++ b/openformats/formats/docx.py
@@ -127,6 +127,10 @@ class DocxFile(object):
             with io.open(self.__document_path, 'r') as f:
                 self.__document = f.read()
 
+            if self.__document.startswith("\ufeff"):
+                # Remove BOM                
+                self.__document = self.__document.replace("\ufeff", "")
+
         return self.__document
 
     def set_document(self, document):


### PR DESCRIPTION
Problem and/or solution
-----------------------
When the docx file contains BOM (Byte Order Mark) bytes the parser cannot get the content. This fix removes the BOM bytes from the beginning of the file, if they exists.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
