### PR TITLE
Remove BOM (Byte Order Mark) bytes from .rels file

### DIFF
--- a/openformats/formats/docx.py
+++ b/openformats/formats/docx.py
@@ -103,6 +103,10 @@ class DocxFile(object):
         base_rels_path = '{}/{}'.format(self.__tmp_folder, '_rels/.rels')
         with io.open(base_rels_path, 'r') as f:
             base_rels = f.read()
+            
+        if base_rels.startswith("\ufeff"):
+            # Remove BOM
+            base_rels = base_rels.replace("\ufeff", "")
 
         document_relative_path = next((
             relationship


### PR DESCRIPTION
Problem and/or solution
-----------------------
When the docx file contains BOM (Byte Order Mark) bytes in the `_rels/.rels` (xml) file of the docx archive, the parser cannot get the content. This fix removes the BOM bytes from the beginning of the `.rels` file, if they exists.

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
