### PR TITLE
 TX-17115: python upgrade 3.9 -> 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: python:3.9
+      - image: python:3.11
     steps:
       - checkout
       - run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install six mock coverage
+          pip install tox
 
       - name: Run Tests
         run: |
-          coverage run -m unittest
-          coverage report
+          tox -r

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Python version
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *,cover
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ run:
 	docker compose up
 
 test:
-	docker compose run --rm --entrypoint='python /app/setup.py' app test
+	docker compose run --rm --entrypoint='pytest' app
 
 shell:
 	docker compose run --rm app shell

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0.2-experimental
-ARG PY_VERSION=3.9
+ARG PY_VERSION=3.11
 
 FROM python:${PY_VERSION}-slim-bullseye as builder
 

--- a/openformats/tests/formats/yaml/test_utils.py
+++ b/openformats/tests/formats/yaml/test_utils.py
@@ -1,9 +1,9 @@
 import unittest
 from collections import OrderedDict
+from unittest.mock import MagicMock
 
 import six
 
-from mock import MagicMock
 from openformats.formats.yaml.utils import YamlGenerator
 from openformats.formats.yaml.yaml_representee_classes import (BlockList,
                                                                FlowList,

--- a/openformats/tests/run_tests.py
+++ b/openformats/tests/run_tests.py
@@ -8,6 +8,8 @@ def run_all(args=None):
         or [
             "openformats/tests",
             "-v",
+            "--junitxml=junit.xml",
+            "--log-cli-level=DEBUG",
             "--cov=openformats",
             "--cov-report=xml",
             "--cov-report=term",

--- a/openformats/tests/run_tests.py
+++ b/openformats/tests/run_tests.py
@@ -1,23 +1,26 @@
-from os.path import abspath, dirname
 import sys
-
-import nose
+import pytest
 
 
 def run_all(args=None):
-    if not args:
-        args = [
-            'nosetests', '--with-xunit', '--with-xcoverage',
-            '--cover-package=openformats', '--cover-erase',
-            '--logging-filter=openformats', '--logging-level=DEBUG',
-            '--verbose',
+    return pytest.main(
+        args
+        or [
+            "openformats/tests",
+            "-v",
+            "--cov=openformats",
+            "--cov-report=xml",
+            "--cov-report=term",
         ]
-
-    nose.run_exit(
-        argv=args,
-        defaultTest=abspath(dirname(__file__))
     )
+    # """Run the openformats test suite.
+
+    # All default options (test path, coverage, JUnit XML, log level) are
+    # declared in ``pytest.ini`` so this entry point, the ``Makefile``
+    # target, and a bare ``pytest`` invocation all behave identically.
+    # """
+    # return pytest.main(list(args) if args else [])
 
 
-if __name__ == '__main__':
-    run_all(sys.argv)
+if __name__ == "__main__":
+    sys.exit(run_all(sys.argv[1:]) or 0)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+; [pytest]
+; testpaths = openformats/tests
+; addopts =
+;     -v
+;     --cov=openformats
+;     --cov-report=xml
+;     --log-level=DEBUG
+;     --log-cli-level=DEBUG

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
-; [pytest]
-; testpaths = openformats/tests
-; addopts =
-;     -v
-;     --cov=openformats
-;     --cov-report=xml
-;     --log-level=DEBUG
-;     --log-cli-level=DEBUG
+[pytest]
+testpaths = openformats/tests
+addopts =
+    -v
+    --cov=openformats
+    --cov-report=term
+    --log-level=DEBUG
+    --log-cli-level=DEBUG

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
-PyYAML==5.4.1
-django==1.11.29
+PyYAML==6.0.2
+django==4.2.26
 mistune==0.8.1
 polib==1.0.3
-pyparsing==2.2.0
+pyparsing==3.0.9
 six
-lxml==4.6.5
+lxml==4.9.4
 beautifulsoup4==4.9.3
 pytest
+pytest-cov
 mock
 
 # InDesign

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,10 @@ mistune==0.8.1
 polib==1.0.3
 pyparsing==3.0.9
 six
-lxml==4.9.4
+lxml==5.0.0
 beautifulsoup4==4.9.3
 pytest
 pytest-cov
-mock
 
 # InDesign
 git+https://github.com/kbairak/ucflib@py3_compatibility

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ import versioneer
 install_requires = [
     "polib==1.0.3",
     "mistune==0.8.1",
-    "PyYAML==5.4.1",
-    "pyparsing==2.2.0",
-    "lxml==4.6.5",
+    "PyYAML==6.0.2",
+    "pyparsing==3.0.9",
+    "lxml==4.9.4",
     "beautifulsoup4==4.9.3",
     "ucflib @ git+https://github.com/kbairak/ucflib.git@py3_compatibility#egg=ucflib-0.2.1",  # noqa
 ]
 
-tests_require = ["nose", "mock", "coverage", "nosexcover"]
+tests_require = ["pytest", "pytest-cov", "mock", "coverage"]
 
 setup(
     name="openformats",

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,13 @@ install_requires = [
     "mistune==0.8.1",
     "PyYAML==6.0.2",
     "pyparsing==3.0.9",
-    "lxml==4.9.4",
+    "lxml==5.0.0",
     "beautifulsoup4==4.9.3",
+    "six",
     "ucflib @ git+https://github.com/kbairak/ucflib.git@py3_compatibility#egg=ucflib-0.2.1",  # noqa
 ]
 
-tests_require = ["pytest", "pytest-cov", "mock", "coverage"]
+tests_require = ["pytest", "pytest-cov", "coverage"]
 
 setup(
     name="openformats",
@@ -23,6 +24,11 @@ setup(
     author="Transifex",
     author_email="support@transifex.com",
     url="https://github.com/transifex/openformats",
+    python_requires=">=3.11",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+    ],
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="openformats.tests.run_tests.run_all",

--- a/testbed/main/models.py
+++ b/testbed/main/models.py
@@ -2,31 +2,28 @@ import json
 from hashlib import md5
 
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class Payload(models.Model):
-    payload_hash = models.CharField(max_length=32, unique=True,
-                                    blank=True, null=True)
+    payload_hash = models.CharField(max_length=32, unique=True, blank=True, null=True)
     payload = models.TextField()
     created = models.DateTimeField(auto_now_add=True)
     last_viewed = models.DateTimeField(blank=True, null=True)
 
     def _presave(self):
-        self.payload_hash = md5(self.payload.encode('utf-8')).hexdigest()
+        self.payload_hash = md5(self.payload.encode("utf-8")).hexdigest()
 
-    def save(self):
+    def save(self, *args, **kwargs):
         self._presave()
-        super(Payload, self).save()
+        super().save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return reverse("testbed_main",
-                       kwargs={'payload_hash': self.payload_hash})
+        return reverse("testbed_main", kwargs={"payload_hash": self.payload_hash})
 
-    def __unicode__(self):
+    def __str__(self):
         payload = json.loads(self.payload)
-        handler = payload.get('handler', None)
+        handler = payload.get("handler", None)
         if handler:
-            return u"{}-{}".format(handler, self.payload_hash[-8:])
-        else:
-            return self.payload_hash[-8:]
+            return "{}-{}".format(handler, self.payload_hash[-8:])
+        return self.payload_hash[-8:]

--- a/testbed/main/urls.py
+++ b/testbed/main/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 
 from testbed.main.views import MainView, ApiView, SaveView
 
 
 urlpatterns = [
-    url(r'^$', MainView.as_view(), name="testbed_home"),
-    url(r'^(?P<payload_hash>\w{32})$', MainView.as_view(),
-        name="testbed_main"),
-    url(r'^api/$', csrf_exempt(ApiView.as_view()), name="testbed_api"),
-    url(r'^save/$', SaveView.as_view(), name="testbed_save")
+    re_path(r'^$', MainView.as_view(), name="testbed_home"),
+    re_path(r'^(?P<payload_hash>\w{32})$', MainView.as_view(),
+            name="testbed_main"),
+    re_path(r'^api/$', csrf_exempt(ApiView.as_view()), name="testbed_api"),
+    re_path(r'^save/$', SaveView.as_view(), name="testbed_save"),
 ]

--- a/testbed/settings.py
+++ b/testbed/settings.py
@@ -14,34 +14,34 @@ ADMINS = (
 MANAGERS = ADMINS
 
 DATABASES = {
-    'default': {
+    "default": {
         # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'ENGINE': 'django.db.backends.sqlite3',
+        "ENGINE": "django.db.backends.sqlite3",
         # Or path to database file if using sqlite3.
-        'NAME': os.path.join(OPENFORMATS_ROOT, 'testbed.sqlite'),
+        "NAME": os.path.join(OPENFORMATS_ROOT, "testbed.sqlite"),
         # The following settings are not used with sqlite3:
-        'USER': '',
-        'PASSWORD': '',
+        "USER": "",
+        "PASSWORD": "",
         # Empty for localhost through domain sockets or '127.0.0.1' for
         # localhost through TCP.
-        'HOST': '',
-        'PORT': '',  # Set to empty string for default.
+        "HOST": "",
+        "PORT": "",  # Set to empty string for default.
     }
 }
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = "America/Chicago"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
 SITE_ID = 1
 
@@ -58,81 +58,81 @@ USE_TZ = False
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/var/www/example.com/media/"
-MEDIA_ROOT = os.path.join(OPENFORMATS_ROOT, 'site_media/media/')
+MEDIA_ROOT = os.path.join(OPENFORMATS_ROOT, "site_media/media/")
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://example.com/media/", "http://media.example.com/"
-MEDIA_URL = '/site_media/media/'
+MEDIA_URL = "/site_media/media/"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
-STATIC_ROOT = os.path.join(OPENFORMATS_ROOT, 'site_media/static/')
+STATIC_ROOT = os.path.join(OPENFORMATS_ROOT, "site_media/static/")
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
-STATIC_URL = '/site_media/static/'
+STATIC_URL = "/site_media/static/"
 
 # Additional locations of static files
 STATICFILES_DIRS = (
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    ('', os.path.join(OPENFORMATS_ROOT, 'static')),
+    ("", os.path.join(OPENFORMATS_ROOT, "static")),
 )
 
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
     # 'django.contrib.staticfiles.finders.DefaultStorageFinder',
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'b2e-1yz^*@(sggyqk=1bpf%al9sd8&8=@j#fxyb%5ewh!x$g9l'
+SECRET_KEY = "b2e-1yz^*@(sggyqk=1bpf%al9sd8&8=@j#fxyb%5ewh!x$g9l"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            os.path.join(OPENFORMATS_ROOT, 'templates'),
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            os.path.join(OPENFORMATS_ROOT, "templates"),
         ],
-    }
+    },
 ]
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 
-ROOT_URLCONF = 'testbed.urls'
+ROOT_URLCONF = "testbed.urls"
 
 # Python dotted path to the WSGI application used by Django's runserver.
-WSGI_APPLICATION = 'testbed.wsgi.application'
+WSGI_APPLICATION = "testbed.wsgi.application"
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.sites',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
-    'testbed.main',
+    "testbed.main",
 )
 
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
+SESSION_SERIALIZER = "django.contrib.sessions.serializers.JSONSerializer"
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
@@ -140,25 +140,21 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
+    "handlers": {
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
         }
     },
-    'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        }
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': True,
+    "loggers": {
+        "django.request": {
+            "handlers": ["mail_admins"],
+            "level": "ERROR",
+            "propagate": True,
         },
-    }
+    },
 }

--- a/testbed/urls.py
+++ b/testbed/urls.py
@@ -1,18 +1,15 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
 # admin.autodiscover()
 
 urlpatterns = [
-    url(r'^', include('testbed.main.urls')),
-
+    re_path(r"^", include("testbed.main.urls")),
     # Examples:
-    # url(r'^testbed/', include('testbed.foo.urls')),
-
+    # re_path(r'^testbed/', include('testbed.foo.urls')),
     # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
+    # re_path(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     # Uncomment the next line to enable the admin:
-    # url(r'^admin/', include(admin.site.urls)),
+    # re_path(r'^admin/', include(admin.site.urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,18 @@
 [tox]
 envlist =
-    py39
+    py311
     report
 
 [testenv]
 install_command = pip install {packages}
 commands =
-    coverage run -m unittest discover
+    pytest
 deps =
     -r{toxinidir}/requirements.txt
-    mock
-    coverage
 
 [testenv:report]
 skipsdist = True
 deps = coverage
 skip_install = true
 commands =
-    # coverage combine --append
     coverage report


### PR DESCRIPTION
Related to [TX-17115: openformats 3.9 -> 3.11](https://xtm-cloud.atlassian.net/browse/TX-17115)

Problem and/or solution
-----------------------

**Changes:**

* Bump Python version to 3.11
* Move test base to utilize tox and pytest - remove nose package
* Upgrade pyyaml to 6.0.2 (5.4.1 breaks in Python 3.11)
* Upgrade django version to match other repositories
* Upgrade pyparsing to 3.0.9 to enable upgrade
* Upgrade lxml to 5.0.0 (4.6.5 has no Python 3.11 support)

Relevant documentation for upgraded packages:

- pyyaml: https://github.com/yaml/pyyaml/blob/main/CHANGES
- lxml: https://lxml.de/5.1/changes-5.1.0.html
- pyparsing: https://github.com/pyparsing/pyparsing/releases?page=3
- nose: https://nose.readthedocs.io/en/latest/usage.html

How to test
-----------

Reviewer checklist
------------------

Code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following [best practices](https://tem.transifex.com)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://tem.transifex.com/github-guide.html#working-on-a-feature)
